### PR TITLE
CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,4 @@ build_script:
 - dotnet build Projects/dotnet-sync/dotnet-sync.csproj
 
 test_script:
-- cd Tests/Dotmim.Sync/Tests
-- sh: dotnet test
-- cmd: dotnet test
+- dotnet test Tests/Dotmim.Sync.Tests/Dotmim.Sync.Tests.csproj

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,9 @@ dotnet_csproj:
   informational_version: '{version}'
 
 build:
-- verbosity: minimal
-- configuration: Release
-- project: Dotmim.Sync.sln
+  verbosity: minimal
+  configuration: Release
+  project: Dotmim.Sync.sln
 
 test_script:
 - cd Tests/Dotmim.Sync/Tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,10 @@ dotnet_csproj:
   file_version: '{version}'
   informational_version: '{version}'
 
+configuration: Release
+
 build:
   verbosity: minimal
-  configuration: Release
   project: Dotmim.Sync.sln
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,9 @@ dotnet_csproj:
   informational_version: '{version}'
 
 build:
-  verbosity: minimal
-  configuration: Release
-  project: Dotmim.Sync.sln
+- verbosity: minimal
+- configuration: Release
+- project: Dotmim.Sync.sln
 
 test_script:
 - cd Tests/Dotmim.Sync/Tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: 0.2.1.{build}
 
 image:
 - Visual Studio 2017
@@ -10,8 +10,21 @@ services:
 - mssql2017
 - mysql
 
+dotnet_csproj:
+  patch: true
+  file: '**\*.csproj'
+  version: '{version}'
+  package_version: '{version}'
+  assembly_version: '{version}'
+  file_version: '{version}'
+  informational_version: '{version}'
+
 build:
   verbosity: minimal
+  configuration: Release
+  project: Dotmim.Sync.sln
 
 test_script:
+- cd Tests/Dotmim.Sync/Tests
 - sh: dotnet test
+- cmd: dotnet test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,12 @@ build:
   verbosity: minimal
   project: Dotmim.Sync.sln
 
+build_script:
+- dotnet build Projects/Dotmim.Sync.Web/Dotmim.Sync.Web.csproj
+- dotnet build Projects/Dotmim.Sync.Sqlite/Dotmim.Sync.Sqlite.csproj
+- dotnet build Projects/Dotmim.Sync.MySql/Dotmim.Sync.MySql.csproj
+- dotnet build Projects/dotnet-sync/dotnet-sync.csproj
+
 test_script:
 - cd Tests/Dotmim.Sync/Tests
 - sh: dotnet test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: 1.0.{build}
+
+image:
+- Visual Studio 2017
+- Ubuntu
+
+platform: Any CPU
+
+services:
+- mssql2017
+- mysql
+
+build:
+  verbosity: minimal
+
+test_script:
+- sh: dotnet test


### PR DESCRIPTION
This adds some building and testing for #76.

Things that DON'T work yet:

* SQL Server & MySQL tests fail due to connection strings (easily fixable, I guess)
* SQL Server on Linux will probably also fail (fixed in #75, where database provisioning does not work)
* packaging and publishing to NuGet (this requires separate steps)