### PR TITLE
CI for unit- and integration tests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,6 +49,13 @@ The script is ready to execute in SQL Server. It contains :
 * A lightweight AdvenureWorks database, acting as the Server database (called **AdventureWorks**)
 * An empty database, acting as the Client database (called **Client**)
 
+## Building from source
+
+1) install VS 2017
+2) install Microsoft SQL Server (localdb is sufficient)
+3) install MySQL (run installMySql.ps1 which automates this using chocolatey)
+4) open "SQLUtils.HelperDB" and modify the connection strings to suit your configuration
+
 ## Need Help
 
 * Check the full documentation, available here : [https://mimetis.github.io/Dotmim.Sync/](https://mimetis.github.io/Dotmim.Sync/)

--- a/Tests/Dotmim.Sync.Tests/MySql/MySqlAllColumnsTests.cs
+++ b/Tests/Dotmim.Sync.Tests/MySql/MySqlAllColumnsTests.cs
@@ -59,7 +59,6 @@ namespace Dotmim.Sync.Test.MySql
 	            [CXml] [xml] NULL,
                 CONSTRAINT [PK_AllColumns] PRIMARY KEY CLUSTERED ( [ClientID] ASC))                
             end;";
-
         private string datas =
         $@"
             INSERT INTO [dbo].[AllColumns]
@@ -194,9 +193,9 @@ namespace Dotmim.Sync.Test.MySql
                     ,'<root><client name=''Doe''>inner Doe client</client></root>')
         ";
 
-        private HelperDB helperDb = new HelperDB();
-        private string serverDbName = "Test_AllColumns_MySql";
-        private string client1DbName = "testallcolumnsmysql";
+        protected HelperDB helperDb = new HelperDB();
+        protected string serverDbName = "Test_AllColumns_MySql";
+        protected string client1DbName = "testallcolumnsmysql";
 
         public String ServerConnectionString => HelperDB.GetDatabaseConnectionString(serverDbName);
         public String ClientMySqlConnectionString => HelperDB.GetMySqlDatabaseConnectionString(client1DbName);
@@ -210,9 +209,14 @@ namespace Dotmim.Sync.Test.MySql
             // create table
             helperDb.ExecuteScript(serverDbName, createTableScript);
 
+        }
+
+        public void InsertTestData()
+        {
             // insert table
             helperDb.ExecuteScript(serverDbName, datas);
         }
+
         public void Dispose()
         {
             helperDb.DeleteDatabase(serverDbName);
@@ -220,6 +224,7 @@ namespace Dotmim.Sync.Test.MySql
         }
 
     }
+
 
     [TestCaseOrderer("Dotmim.Sync.Tests.Misc.PriorityOrderer", "Dotmim.Sync.Tests")]
     public class MySqlAllColumnsTests : IClassFixture<MySqlAllColumnsFixture>
@@ -250,8 +255,14 @@ namespace Dotmim.Sync.Test.MySql
         [Fact, TestPriority(1)]
         public async Task InitializeAndSync()
         {
-            var session = await agent.SynchronizeAsync();
+            // Arrange
+            // insert 10 test rows
+            this.fixture.InsertTestData();
 
+            // Act
+            var session = await agent.SynchronizeAsync();
+            
+            // Assert
             Assert.Equal(10, session.TotalChangesDownloaded);
             Assert.Equal(0, session.TotalChangesUploaded);
 
@@ -376,7 +387,6 @@ namespace Dotmim.Sync.Test.MySql
         [Fact, TestPriority(3)]
         public async Task OneRowFromServer()
         {
-
             var clientId = InsertARow(fixture.ServerConnectionString);
 
             var session = await agent.SynchronizeAsync();

--- a/Tests/Dotmim.Sync.Tests/SqlUtils/HelperDB.cs
+++ b/Tests/Dotmim.Sync.Tests/SqlUtils/HelperDB.cs
@@ -10,9 +10,21 @@ namespace Dotmim.Sync.Test.SqlUtils
 {
     public class HelperDB
     {
-        public static String GetDatabaseConnectionString(string dbName) => $@"Data Source=(localdb)\MSSQLLocalDB; Initial Catalog={dbName}; Integrated Security=true;";
+        /// <summary>
+        /// Returns the database server to be used in the untittests - note that this is the connection to appveyor SQL Server 2008 instance!
+        /// see: https://www.appveyor.com/docs/services-databases/#mysql
+        /// </summary>
+        /// <param name="dbName"></param>
+        /// <returns></returns>
+        public static String GetDatabaseConnectionString(string dbName) => $@"Server=(local)\SQL2008R2SP2;Database={dbName};UID=sa;PWD=Password12!";
+        /// <summary>
+        /// Returns the database server to be used in the untittests - note that this is the connection to appveyor MySQL 5.7 x64 instance!
+        /// see: https://www.appveyor.com/docs/services-databases/#mysql
+        /// </summary>
+        /// <param name="dbName"></param>
+        /// <returns></returns>
+        public static string GetMySqlDatabaseConnectionString(string dbName) => $@"Server=127.0.0.1; Port=3306; Database={dbName}; Uid=root; Pwd=Password12!";
 
-        public static string GetMySqlDatabaseConnectionString(string dbName) => $@"Server=127.0.0.1; Port=3306; Database={dbName}; Uid=root; Pwd=azerty31$;";
         /// <summary>
         /// Generate a database
         /// </summary>

--- a/Tests/Dotmim.Sync.Tests/SqlUtils/HelperDB.cs
+++ b/Tests/Dotmim.Sync.Tests/SqlUtils/HelperDB.cs
@@ -11,12 +11,12 @@ namespace Dotmim.Sync.Test.SqlUtils
     public class HelperDB
     {
         /// <summary>
-        /// Returns the database server to be used in the untittests - note that this is the connection to appveyor SQL Server 2008 instance!
+        /// Returns the database server to be used in the untittests - note that this is the connection to appveyor SQL Server 2016 instance!
         /// see: https://www.appveyor.com/docs/services-databases/#mysql
         /// </summary>
         /// <param name="dbName"></param>
         /// <returns></returns>
-        public static String GetDatabaseConnectionString(string dbName) => $@"Server=(local)\SQL2008R2SP2;Database={dbName};UID=sa;PWD=Password12!";
+        public static String GetDatabaseConnectionString(string dbName) => $@"Server=(localdb)\SQL2016;Database={dbName};UID=sa;PWD=Password12!";
         /// <summary>
         /// Returns the database server to be used in the untittests - note that this is the connection to appveyor MySQL 5.7 x64 instance!
         /// see: https://www.appveyor.com/docs/services-databases/#mysql

--- a/Tests/Dotmim.Sync.Tests/SyncProvAndDeprovTests.cs
+++ b/Tests/Dotmim.Sync.Tests/SyncProvAndDeprovTests.cs
@@ -124,7 +124,7 @@ namespace Dotmim.Sync.Test
                 using (var cmd = new SqlCommand(commandText, sqlConnection))
                 {
                     int nb = (int)cmd.ExecuteScalar();
-                    Assert.Equal(0, nb);
+                    Assert.Equal(2, nb); // "On purpose, the flag SyncProvision.All does not include the SyncProvision.Table, too dangerous..."
                 }
                 commandText = "Select count(*) from sys.procedures";
                 using (var cmd = new SqlCommand(commandText, sqlConnection))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,12 @@ version: 0.2.1.{build}
 
 image:
 - Visual Studio 2017
-- Ubuntu
 
 platform: Any CPU
 
 services:
-- mssql2008r2sp2
 - mysql
+- mssql2016
 
 dotnet_csproj:
   patch: true
@@ -24,7 +23,11 @@ configuration: Release
 build:
   verbosity: minimal
   project: Dotmim.Sync.sln
-
+  
+before_build:
+  # Display .NET Core version
+  - cmd: dotnet --version
+  
 build_script:
 - dotnet build Projects/Dotmim.Sync.Web/Dotmim.Sync.Web.csproj
 - dotnet build Projects/Dotmim.Sync.Sqlite/Dotmim.Sync.Sqlite.csproj

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+version: 0.2.1.{build}
+
+image:
+- Visual Studio 2017
+- Ubuntu
+
+platform: Any CPU
+
+services:
+- mssql2008r2sp2
+- mysql
+
+dotnet_csproj:
+  patch: true
+  file: '**\*.csproj'
+  version: '{version}'
+  package_version: '{version}'
+  assembly_version: '{version}'
+  file_version: '{version}'
+  informational_version: '{version}'
+
+configuration: Release
+
+build:
+  verbosity: minimal
+  project: Dotmim.Sync.sln
+
+build_script:
+- dotnet build Projects/Dotmim.Sync.Web/Dotmim.Sync.Web.csproj
+- dotnet build Projects/Dotmim.Sync.Sqlite/Dotmim.Sync.Sqlite.csproj
+- dotnet build Projects/Dotmim.Sync.MySql/Dotmim.Sync.MySql.csproj
+- dotnet build Projects/dotnet-sync/dotnet-sync.csproj
+
+test_script:
+- dotnet test Tests/Dotmim.Sync.Tests/Dotmim.Sync.Tests.csproj

--- a/installMySql.ps1
+++ b/installMySql.ps1
@@ -1,0 +1,8 @@
+# install chocolatey
+Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+#install mysql
+cinst mysql -y
+
+#set initial root user password to be the one used by dotmim sync
+mysqladmin -u root password azerty31$

--- a/installMySql.ps1
+++ b/installMySql.ps1
@@ -5,4 +5,4 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.We
 cinst mysql -y
 
 #set initial root user password to be the one used by dotmim sync
-mysqladmin -u root password azerty31$
+mysqladmin -u root password Password12!

--- a/uninstallMySql.ps1
+++ b/uninstallMySql.ps1
@@ -1,0 +1,1 @@
+choco uninstall mysql -y --remove-dependencies


### PR DESCRIPTION
Hi!

1) I fixed the automated tests on my dev machine 
2) used the appveyor.yml of #78 as foundation (big thanks to @ashalkhakov)
    but had to change it a bit to get the tests to work

All tests now are green on appveyor except of two:

1) Dotmim.Sync.Test.MySql.MySqlAllColumnsTests.OneRowFromServer
...fails due to the DATETIME vs DATETIME(6) issue with MySql version 5.7 (which is the only one available on appveyor)
Please refer to this issue: #77

2) Dotmim.Sync.Tests.SyncConflictsTests.ConflictOnUniqueConstraint 
...also fails on my dev machine. I do not know why, yet. Maybe you can have a look @Mimetis ? :-)

In order to use this CI for Dotmim.Sync:
1) Login to appveyor using your github account
2) [add the Dotmim.Sync project](https://1drv.ms/u/s!AhVbOiFFuzx_11vAFiYnRdNjervV)
3) [configure the environment to start MySql and mssql2016](https://1drv.ms/u/s!AhVbOiFFuzx_11rRJAQCLXqgQNrC)

not dotmim.sync has CI! WHOOP WHOOP :+1