### PR TITLE
83 ci fixes

### DIFF
--- a/Projects/Dotmim.Sync.Core/Serialization/DmBinaryConverter/Converters/ObjectConverter.cs
+++ b/Projects/Dotmim.Sync.Core/Serialization/DmBinaryConverter/Converters/ObjectConverter.cs
@@ -1,21 +1,20 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Globalization;
-using System.Text;
 
 namespace Dotmim.Sync.Serialization.Converters
 {
     public abstract class ObjectConverter
     {
 
-        private static Dictionary<Type, ObjectConverter> converters = new Dictionary<Type, ObjectConverter>();
+        private static ConcurrentDictionary<Type, ObjectConverter> converters = new ConcurrentDictionary<Type, ObjectConverter>();
 
         static ObjectConverter()
         {
-            converters.Add(typeof(Type), new ObjectTypeConverter());
-            converters.Add((typeof(Type).GetType()), new ObjectTypeConverter());
-            converters.Add(typeof(CultureInfo), new CultureInfoConverter());
-            converters.Add(typeof(Version), new VersionConverter());
+            converters.TryAdd(typeof(Type), new ObjectTypeConverter());
+            converters.TryAdd((typeof(Type).GetType()), new ObjectTypeConverter());
+            converters.TryAdd(typeof(CultureInfo), new CultureInfoConverter());
+            converters.TryAdd(typeof(Version), new VersionConverter());
 
         }
         /// <summary>
@@ -26,7 +25,7 @@ namespace Dotmim.Sync.Serialization.Converters
             if (ObjectConverter.converters.ContainsKey(type))
                 throw new ArgumentException($"Converter {type.Name} already exists.");
 
-            ObjectConverter.converters.Add(type, converter);
+            ObjectConverter.converters.TryAdd(type, converter);
         }
 
         /// <summary>

--- a/Projects/Dotmim.Sync.MySql/Builders/MySqlObjectNames.cs
+++ b/Projects/Dotmim.Sync.MySql/Builders/MySqlObjectNames.cs
@@ -11,9 +11,9 @@ namespace Dotmim.Sync.MySql
     {
         public const string TimestampValue = "ROUND(UNIX_TIMESTAMP(CURTIME(4)) * 10000)";
 
-        internal const string insertTriggerName = "`{0}_insert`";
-        internal const string updateTriggerName = "`{0}_update`";
-        internal const string deleteTriggerName = "`{0}_delete`";
+        internal const string insertTriggerName = "`{0}_insert_trigger`";
+        internal const string updateTriggerName = "`{0}_update_trigger`";
+        internal const string deleteTriggerName = "`{0}_delete_trigger`";
 
         internal const string selectChangesProcName = "`{0}_selectchanges`";
         internal const string selectChangesProcNameWithFilters = "`{0}_{1}_selectchanges`";

--- a/Projects/Dotmim.Sync.SqlServer/Builders/SqlObjectNames.cs
+++ b/Projects/Dotmim.Sync.SqlServer/Builders/SqlObjectNames.cs
@@ -8,9 +8,9 @@ namespace Dotmim.Sync.SqlServer.Builders
 {
     public class SqlObjectNames
     {
-        internal const string insertTriggerName = "[{0}].[{1}_insert]";
-        internal const string updateTriggerName = "[{0}].[{1}_update]";
-        internal const string deleteTriggerName = "[{0}].[{1}_delete]";
+        internal const string insertTriggerName = "[{0}].[{1}_insert_trigger]";
+        internal const string updateTriggerName = "[{0}].[{1}_update_trigger]";
+        internal const string deleteTriggerName = "[{0}].[{1}_delete_trigger]";
 
         internal const string selectChangesProcName = "[{0}].[{1}_selectchanges]";
         internal const string selectChangesProcNameWithFilters = "[{0}].[{1}_{2}_selectchanges]";

--- a/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
@@ -1,9 +1,9 @@
 ﻿using Dotmim.Sync.Builders;
 using Dotmim.Sync.Data;
-using Dotmim.Sync.Log;
 using Dotmim.Sync.SqlServer.Manager;
 using Microsoft.SqlServer.Server;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -22,7 +22,7 @@ namespace Dotmim.Sync.SqlServer.Builders
         private SqlDbMetadata sqlMetadata;
 
         // Derive Parameters cache
-        private static Dictionary<string, List<SqlParameter>> derivingParameters = new Dictionary<string, List<SqlParameter>>();
+        private static ConcurrentDictionary<string, List<SqlParameter>> derivingParameters = new ConcurrentDictionary<string, List<SqlParameter>>();
 
         public override DbConnection Connection
         {
@@ -431,7 +431,7 @@ namespace Dotmim.Sync.SqlServer.Builders
                     foreach (var p in parameters)
                         arrayParameters.Add(p.Clone());
 
-                    derivingParameters.Add(textParser.FullUnquotedString, arrayParameters);
+                    derivingParameters.TryAdd(textParser.FullUnquotedString, arrayParameters);
                 }
 
                 if (command.Parameters[0].ParameterName == "@RETURN_VALUE")

--- a/Projects/Dotmim.Sync.Sqlite/Builders/SQLiteObjectNames.cs
+++ b/Projects/Dotmim.Sync.Sqlite/Builders/SQLiteObjectNames.cs
@@ -11,9 +11,9 @@ namespace Dotmim.Sync.Sqlite
     {
         public const string TimestampValue = "replace(strftime('%Y%m%d%H%M%f', 'now'), '.', '')";
 
-        internal const string insertTriggerName = "[{0}_insert]";
-        internal const string updateTriggerName = "[{0}_update]";
-        internal const string deleteTriggerName = "[{0}_delete]";
+        internal const string insertTriggerName = "[{0}_insert_trigger]";
+        internal const string updateTriggerName = "[{0}_update_trigger]";
+        internal const string deleteTriggerName = "[{0}_delete_trigger]";
 
         private Dictionary<DbCommandType, String> names = new Dictionary<DbCommandType, string>();
         private ObjectNameParser tableName, trackingName;

--- a/Tests/Dotmim.Sync.Tests/AssemblyInfo.cs
+++ b/Tests/Dotmim.Sync.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Tests/Dotmim.Sync.WebApi2.Tests/SqlUtils/HelperDB.cs
+++ b/Tests/Dotmim.Sync.WebApi2.Tests/SqlUtils/HelperDB.cs
@@ -8,21 +8,42 @@ using System.IO;
 namespace Dotmim.Sync.Test.SqlUtils
 {
     public class HelperDB
-    {
+    {  
         /// <summary>
         /// Returns the database server to be used in the untittests - note that this is the connection to appveyor SQL Server 2016 instance!
         /// see: https://www.appveyor.com/docs/services-databases/#mysql
         /// </summary>
         /// <param name="dbName"></param>
         /// <returns></returns>
-        public static String GetDatabaseConnectionString(string dbName) => $@"Server=(local)\SQL2016;Database={dbName};UID=sa;PWD=Password12!";
+        public static String GetDatabaseConnectionString(string dbName)
+        {
+
+            // check if we are running on appveyor or not
+            string isOnAppVeyor = Environment.GetEnvironmentVariable("APPVEYOR");
+
+            if (!String.IsNullOrEmpty(isOnAppVeyor) && isOnAppVeyor.ToLowerInvariant() == "true")
+                return $@"Server=(local)\SQL2016;Database={dbName};UID=sa;PWD=Password12!";
+            else
+                return $@"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog={dbName};Integrated Security=true;";
+
+        }
         /// <summary>
         /// Returns the database server to be used in the untittests - note that this is the connection to appveyor MySQL 5.7 x64 instance!
         /// see: https://www.appveyor.com/docs/services-databases/#mysql
         /// </summary>
         /// <param name="dbName"></param>
         /// <returns></returns>
-        public static string GetMySqlDatabaseConnectionString(string dbName) => $@"Server=127.0.0.1; Port=3306; Database={dbName}; Uid=root; Pwd=Password12!";
+        public static string GetMySqlDatabaseConnectionString(string dbName)
+        {
+            // check if we are running on appveyor or not
+            string isOnAppVeyor = Environment.GetEnvironmentVariable("APPVEYOR");
+
+            if (!String.IsNullOrEmpty(isOnAppVeyor) && isOnAppVeyor.ToLowerInvariant() == "true")
+                return $@"Server=127.0.0.1; Port=3306; Database={dbName}; Uid=root; Pwd=Password12!";
+            else
+                return $@"Server=127.0.0.1; Port=3306; Database={dbName}; Uid=root; Pwd=azerty31$;";
+
+        }
 
         /// <summary>
         /// Generate a database


### PR DESCRIPTION
Added assembly attribute 

      [assembly: CollectionBehavior(DisableTestParallelization = true)]

=> tests are now executed sequentially (not parallel) which means they are slower, but they do not fail


Fixed trigger creation by re-adding the standard postfix "_trigger" to SQLite,MSSQL,MySQL.
If no custom prefix was provided the triggers names would clash with those of the stored procedures. This caused nearly all tests to fail.

This fixed issue #83
