### PR TITLE
Fix for #51 - when using webproxy, pre/postfixes of triggers are ignored

### DIFF
--- a/Projects/Dotmim.Sync.Core/Dm/DmTableSurrogate.cs
+++ b/Projects/Dotmim.Sync.Core/Dm/DmTableSurrogate.cs
@@ -187,6 +187,8 @@ namespace Dotmim.Sync.Data.Surrogate
             dt.TrackingTablesSuffix = this.TrackingTablesSuffix;
             dt.StoredProceduresPrefix = this.StoredProceduresPrefix;
             dt.StoredProceduresSuffix = this.StoredProceduresSuffix;
+            dt.TriggersPrefix = this.TriggersPrefix;
+            dt.TriggersSuffix = this.TriggersSuffix;
 
             for (int i = 0; i < this.Columns.Count; i++)
             {


### PR DESCRIPTION
Setting up trigger pre- and postfixes using a webproxy (asp.net) does not work.
The pre- and postfixes are ignored on the server side (verifyable with SqlServer provider)

Completes issue #51 