### PR TITLE
Fix - SyncConfiguration is overriden before BatchDirectory is persisted

### DIFF
--- a/Projects/Dotmim.Sync.Core/CoreProvider.GetChanges.cs
+++ b/Projects/Dotmim.Sync.Core/CoreProvider.GetChanges.cs
@@ -52,7 +52,7 @@ namespace Dotmim.Sync
                 }
 
                 // create local directory
-                if (!String.IsNullOrEmpty(message.BatchDirectory) && !Directory.Exists(message.BatchDirectory))
+                if (message.DownloadBatchSizeInKB > 0 && !String.IsNullOrEmpty(message.BatchDirectory) && !Directory.Exists(message.BatchDirectory))
                     Directory.CreateDirectory(message.BatchDirectory);
 
                 // batch info containing changes

--- a/Projects/Dotmim.Sync.Web.Server/WebProxyServerProvider.cs
+++ b/Projects/Dotmim.Sync.Web.Server/WebProxyServerProvider.cs
@@ -297,6 +297,9 @@ namespace Dotmim.Sync.Web.Server
             else
                 httpMessageBeginSession = (httpMessage.Content as JObject).ToObject<HttpMessageBeginSession>();
 
+            // client specific path
+            var batchDirectory = httpMessageBeginSession.SyncConfiguration.BatchDirectory;
+            
             // the Conf is hosted by the server ? if not, get the client configuration
             httpMessageBeginSession.SyncConfiguration = 
                 this.Configuration ?? httpMessageBeginSession.SyncConfiguration;
@@ -307,7 +310,7 @@ namespace Dotmim.Sync.Web.Server
                         httpMessageBeginSession as MessageBeginSession);
 
             // One exception : don't touch the batch directory, it's very client specific and may differ from server side
-            conf.BatchDirectory = httpMessageBeginSession.SyncConfiguration.BatchDirectory;
+            conf.BatchDirectory = batchDirectory;
             httpMessageBeginSession.SyncConfiguration = conf;
 
             httpMessage.SyncContext = ctx;


### PR DESCRIPTION
Also, do not create BatchDirectory on client, if BatchMode is off.