### PR TITLE
#300 - fixing issue causing dataloss when server session is lost whil…

### DIFF
--- a/Projects/Dotmim.Sync.Web.Client/HttpMessageArgs.cs
+++ b/Projects/Dotmim.Sync.Web.Client/HttpMessageArgs.cs
@@ -1,13 +1,4 @@
-﻿using Dotmim.Sync.Batch;
-using Dotmim.Sync.Builders;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using Dotmim.Sync.Enumerations;
-using System.Runtime.Serialization;
-using System.Data.Common;
-
-namespace Dotmim.Sync.Web.Client
+﻿namespace Dotmim.Sync.Web.Client
 {
     public class HttpMessageSendChangesResponseArgs : ProgressArgs
     {
@@ -20,22 +11,27 @@ namespace Dotmim.Sync.Web.Client
 
     public class HttpMessageGetMoreChangesRequestArgs : ProgressArgs
     {
-        public HttpMessageGetMoreChangesRequestArgs(byte[] content) : base(null, null, null)
-            => this.Content = content;
+        public HttpMessageGetMoreChangesRequestArgs(HttpMessageGetMoreChangesRequest request) 
+            : base(request.SyncContext, null, null)
+        {
+            this.Request = request;
+        }
 
-        public byte[] Content { get; }
+        public HttpMessageGetMoreChangesRequest Request { get; }
         public override int EventId => 51;
     }
 
     public class HttpMessageSendChangesRequestArgs : ProgressArgs
     {
-        public HttpMessageSendChangesRequestArgs(byte[] content) : base(null, null, null)
-            => this.Content = content;
+        public HttpMessageSendChangesRequestArgs(HttpMessageSendChangesRequest request) 
+            : base(request.SyncContext, null, null)
+        {
+            this.Request = request;
+        }
 
-        public byte[] Content { get; }
+        public HttpMessageSendChangesRequest Request { get; }
         public override int EventId => 52;
     }
-
 
     public class HttpMessageEnsureScopesResponseArgs : ProgressArgs
     {

--- a/Projects/Dotmim.Sync.Web.Client/WebClientOrchestrator.cs
+++ b/Projects/Dotmim.Sync.Web.Client/WebClientOrchestrator.cs
@@ -300,11 +300,11 @@ namespace Dotmim.Sync.Web.Client
                 changesToSend.IsLastBatch = true;
                 changesToSend.BatchIndex = 0;
 
+                await this.InterceptAsync(new HttpMessageSendChangesRequestArgs(changesToSend), cancellationToken).ConfigureAwait(false);
+
                 // serialize message
                 var serializer = this.SerializerFactory.GetSerializer<HttpMessageSendChangesRequest>();
                 var binaryData = await serializer.SerializeAsync(changesToSend);
-
-                await this.InterceptAsync(new HttpMessageSendChangesRequestArgs(binaryData), cancellationToken).ConfigureAwait(false);
 
                 httpMessageContent = await this.httpRequestHandler.ProcessRequestAsync<HttpMessageSendChangesResponse>
                     (this.HttpClient, this.ServiceUri, binaryData, HttpStep.SendChanges, ctx.SessionId, scope.Name,
@@ -331,11 +331,11 @@ namespace Dotmim.Sync.Web.Client
                     changesToSend.IsLastBatch = bpi.IsLastBatch;
                     changesToSend.BatchIndex = bpi.Index;
 
+                    await this.InterceptAsync(new HttpMessageSendChangesRequestArgs(changesToSend), cancellationToken).ConfigureAwait(false);
+
                     // serialize message
                     var serializer = this.SerializerFactory.GetSerializer<HttpMessageSendChangesRequest>();
                     var binaryData = await serializer.SerializeAsync(changesToSend);
-
-                    await this.InterceptAsync(new HttpMessageSendChangesRequestArgs(binaryData), cancellationToken).ConfigureAwait(false);
 
                     httpMessageContent = await this.httpRequestHandler.ProcessRequestAsync<HttpMessageSendChangesResponse>
                         (this.HttpClient, this.ServiceUri, binaryData, HttpStep.SendChanges, ctx.SessionId, scope.Name,
@@ -410,11 +410,11 @@ namespace Dotmim.Sync.Web.Client
                     // Create the message enveloppe
                     var httpMessage = new HttpMessageGetMoreChangesRequest(ctx, requestBatchIndex);
 
+                    await this.InterceptAsync(new HttpMessageGetMoreChangesRequestArgs(httpMessage), cancellationToken).ConfigureAwait(false);
+
                     // serialize message
                     var serializer = this.SerializerFactory.GetSerializer<HttpMessageGetMoreChangesRequest>();
                     var binaryData = await serializer.SerializeAsync(httpMessage);
-
-                    await this.InterceptAsync(new HttpMessageGetMoreChangesRequestArgs(binaryData), cancellationToken).ConfigureAwait(false);
 
                     httpMessageContent = await this.httpRequestHandler.ProcessRequestAsync<HttpMessageSendChangesResponse>(
                                this.HttpClient, this.ServiceUri, binaryData, HttpStep.GetMoreChanges, ctx.SessionId, scope.Name,
@@ -515,7 +515,7 @@ namespace Dotmim.Sync.Web.Client
                     var serializer2 = this.SerializerFactory.GetSerializer<HttpMessageGetMoreChangesRequest>();
                     var binaryData2 = await serializer2.SerializeAsync(httpMessage);
 
-                    await this.InterceptAsync(new HttpMessageGetMoreChangesRequestArgs(binaryData), cancellationToken).ConfigureAwait(false);
+                    await this.InterceptAsync(new HttpMessageGetMoreChangesRequestArgs(httpMessage), cancellationToken).ConfigureAwait(false);
 
                     httpMessageContent = await this.httpRequestHandler.ProcessRequestAsync<HttpMessageSendChangesResponse>(
                                this.HttpClient, this.ServiceUri, binaryData2, HttpStep.GetMoreChanges, ctx.SessionId, this.ScopeName,
@@ -573,7 +573,7 @@ namespace Dotmim.Sync.Web.Client
             var serializer = this.SerializerFactory.GetSerializer<HttpMessageSendChangesRequest>();
             var binaryData = await serializer.SerializeAsync(changesToSend);
 
-            await this.InterceptAsync(new HttpMessageSendChangesRequestArgs(binaryData), cancellationToken).ConfigureAwait(false);
+            await this.InterceptAsync(new HttpMessageSendChangesRequestArgs(changesToSend), cancellationToken).ConfigureAwait(false);
 
 
             // response
@@ -633,7 +633,7 @@ namespace Dotmim.Sync.Web.Client
                     var serializer2 = this.SerializerFactory.GetSerializer<HttpMessageGetMoreChangesRequest>();
                     var binaryData2 = await serializer2.SerializeAsync(httpMessage);
 
-                    await this.InterceptAsync(new HttpMessageGetMoreChangesRequestArgs(binaryData), cancellationToken).ConfigureAwait(false);
+                    await this.InterceptAsync(new HttpMessageGetMoreChangesRequestArgs(httpMessage), cancellationToken).ConfigureAwait(false);
 
                     httpMessageContent = await this.httpRequestHandler.ProcessRequestAsync<HttpMessageSendChangesResponse>(
                                this.HttpClient, this.ServiceUri, binaryData2, HttpStep.GetMoreChanges, ctx.SessionId, this.ScopeName,
@@ -697,7 +697,7 @@ namespace Dotmim.Sync.Web.Client
             var serializer = this.SerializerFactory.GetSerializer<HttpMessageSendChangesRequest>();
             var binaryData = await serializer.SerializeAsync(changesToSend);
 
-            await this.InterceptAsync(new HttpMessageSendChangesRequestArgs(binaryData), cancellationToken).ConfigureAwait(false);
+            await this.InterceptAsync(new HttpMessageSendChangesRequestArgs(changesToSend), cancellationToken).ConfigureAwait(false);
 
 
             // response

--- a/Projects/Dotmim.Sync.Web.Server/WebServerOrchestrator.cs
+++ b/Projects/Dotmim.Sync.Web.Server/WebServerOrchestrator.cs
@@ -501,10 +501,13 @@ namespace Dotmim.Sync.Web.Server
             // FIRST STEP : receive client changes
             // ------------------------------------------------------------
 
+            // ensure that the blientBatchInfo is still available in the session - it **must** only be null when the batchIndex is 0!!
+            if (sessionCache.ClientBatchInfo == null && httpMessage.BatchIndex != 0)
+                throw new SyncException("Session loss: No batchPartInfo could found for the current sessionId. It seems the session was lost. Please try again.");
+
             // We are receiving changes from client
             // BatchInfo containing all BatchPartInfo objects
             // Retrieve batchinfo instance if exists
-
             // Get batch info from session cache if exists, otherwise create it
             if (sessionCache.ClientBatchInfo == null)
                 sessionCache.ClientBatchInfo = new BatchInfo(clientWorkInMemory, Schema, this.Options.BatchDirectory);
@@ -562,7 +565,7 @@ namespace Dotmim.Sync.Web.Server
             SessionCache sessionCache, CancellationToken cancellationToken = default, IProgress<ProgressArgs> progress = null)
         {
             if (sessionCache.ServerBatchInfo == null)
-                throw new ArgumentNullException("batchInfo stored in session can't be null if request more batch part info.");
+                throw new SyncException("Session loss: No batchPartInfo could found for the current sessionId. It seems the session was lost. Please try again.");
 
             return GetChangesResponseAsync(httpMessage.SyncContext, sessionCache.RemoteClientTimestamp,
                 sessionCache.ServerBatchInfo, sessionCache.ClientChangesApplied,

--- a/Tests/Dotmim.Sync.Tests/HttpTests.cs
+++ b/Tests/Dotmim.Sync.Tests/HttpTests.cs
@@ -29,159 +29,10 @@ using Xunit.Abstractions;
 
 namespace Dotmim.Sync.Tests
 {
-    [TestCaseOrderer("Dotmim.Sync.Tests.Misc.PriorityOrderer", "Dotmim.Sync.Tests")]
-    public abstract class HttpTests : IClassFixture<HelperProvider>, IDisposable
+    public abstract class HttpTests : HttpTestsBase
     {
-        private Stopwatch stopwatch;
-
-        /// <summary>
-        /// Gets the sync tables involved in the tests
-        /// </summary>
-        public abstract string[] Tables { get; }
-
-        /// <summary>
-        /// Gets the clients type we want to tests
-        /// </summary>
-        public abstract List<ProviderType> ClientsType { get; }
-
-        /// <summary>
-        /// Gets the server type we want to test
-        /// </summary>
-        public abstract ProviderType ServerType { get; }
-
-        /// <summary>
-        /// Gets if fiddler is in use
-        /// </summary>
-        public abstract bool UseFiddler { get; }
-
-        /// <summary>
-        /// Service Uri provided by kestrell when starts
-        /// </summary>
-        public string ServiceUri { get; private set; }
-
-        /// <summary>
-        /// Gets the Web Server Orchestrator used for the tests
-        /// </summary>
-        public WebServerOrchestrator WebServerOrchestrator { get; private set; }
-
-        /// <summary>
-        /// Get the server rows count
-        /// </summary>
-        public abstract int GetServerDatabaseRowsCount((string DatabaseName, ProviderType ProviderType, CoreProvider Provider) t);
-
-        /// <summary>
-        /// Create a provider
-        /// </summary>
-        public abstract CoreProvider CreateProvider(ProviderType providerType, string dbName);
-
-        /// <summary>
-        /// Create database, seed it, with or without schema
-        /// </summary>
-        public abstract Task EnsureDatabaseSchemaAndSeedAsync((string DatabaseName,
-            ProviderType ProviderType, CoreProvider Provider) t, bool useSeeding = false, bool useFallbackSchema = false);
-
-
-        /// <summary>
-        /// Create an empty database
-        /// </summary>
-        public abstract Task CreateDatabaseAsync(ProviderType providerType, string dbName, bool recreateDb = true);
-
-
-        // abstract fixture used to run the tests
-        protected readonly HelperProvider fixture;
-
-        // Current test running
-        private ITest test;
-        private KestrellTestServer kestrell;
-
-
-        /// <summary>
-        /// Gets the remote orchestrator and its database name
-        /// </summary>
-        public (string DatabaseName, ProviderType ProviderType, CoreProvider Provider) Server { get; private set; }
-
-        /// <summary>
-        /// Gets the dictionary of all local orchestrators with database name as key
-        /// </summary>
-        public List<(string DatabaseName, ProviderType ProviderType, CoreProvider Provider)> Clients { get; set; }
-
-        /// <summary>
-        /// Gets a bool indicating if we should generate the schema for tables
-        /// </summary>
-        public bool UseFallbackSchema => ServerType == ProviderType.Sql;
-
-        /// <summary>
-        /// ctor
-        /// </summary>
-        public HttpTests(HelperProvider fixture, ITestOutputHelper output)
+        protected HttpTests(HelperProvider fixture, ITestOutputHelper output) : base(fixture, output)
         {
-
-            // Getting the test running
-            var type = output.GetType();
-            var testMember = type.GetField("test", BindingFlags.Instance | BindingFlags.NonPublic);
-            this.test = (ITest)testMember.GetValue(output);
-
-            this.stopwatch = Stopwatch.StartNew();
-
-            this.fixture = fixture;
-
-            // Since we are creating a lot of databases
-            // each database will have its own pool
-            // Droping database will not clear the pool associated
-            // So clear the pools on every start of a new test
-            SqlConnection.ClearAllPools();
-            MySqlConnection.ClearAllPools();
-
-            // get the server provider (and db created) without seed
-            var serverDatabaseName = HelperDatabase.GetRandomName("http_sv_");
-
-            var serverProvider = this.CreateProvider(this.ServerType, serverDatabaseName);
-
-            // create web remote orchestrator
-            this.WebServerOrchestrator = new WebServerOrchestrator(serverProvider, new SyncOptions(), new WebServerOptions(), new SyncSetup());
-
-            // public property
-            this.Server = (serverDatabaseName, this.ServerType, serverProvider);
-
-            // Create a kestrell server
-            this.kestrell = new KestrellTestServer(this.WebServerOrchestrator, this.UseFiddler);
-
-            // start server and get uri
-            this.ServiceUri = this.kestrell.Run();
-
-            // Get all clients providers
-            Clients = new List<(string, ProviderType, CoreProvider)>(this.ClientsType.Count);
-
-            // Generate Client database
-            foreach (var clientType in this.ClientsType)
-            {
-                var dbCliName = HelperDatabase.GetRandomName("http_cli_");
-                var localProvider = this.CreateProvider(clientType, dbCliName);
-                this.Clients.Add((dbCliName, clientType, localProvider));
-            }
-
-        }
-
-        /// <summary>
-        /// Drop all databases used for the tests
-        /// </summary>
-        public void Dispose()
-        {
-            //HelperDatabase.DropDatabase(this.ServerType, Server.DatabaseName);
-
-            //foreach (var client in Clients)
-            //{
-            //    HelperDatabase.DropDatabase(client.ProviderType, client.DatabaseName);
-            //}
-
-            this.kestrell.Dispose();
-
-            this.stopwatch.Stop();
-
-            var str = $"{test.TestCase.DisplayName} : {this.stopwatch.Elapsed.Minutes}:{this.stopwatch.Elapsed.Seconds}.{this.stopwatch.Elapsed.Milliseconds}";
-            Console.WriteLine(str);
-            Debug.WriteLine(str);
-
         }
 
         [Fact, TestPriority(1)]
@@ -805,8 +656,7 @@ namespace Dotmim.Sync.Tests
 
 
         }
-
-
+        
         /// <summary>
         /// Insert one row on each client, should be sync on server and clients
         /// </summary>
@@ -845,8 +695,7 @@ namespace Dotmim.Sync.Tests
                 Assert.Equal("HttpConverterNotConfiguredException", exception.TypeName);
             }
         }
-
-
+        
         /// <summary>
         /// Check web interceptors are working correctly
         /// </summary>
@@ -914,7 +763,6 @@ namespace Dotmim.Sync.Tests
                 Assert.Equal(0, s.TotalChangesUploaded);
             }
         }
-
 
         /// <summary>
         /// Check web interceptors are working correctly
@@ -1005,8 +853,7 @@ namespace Dotmim.Sync.Tests
             }
 
         }
-
-
+        
         /// <summary>
         /// Insert one row on each client, should be sync on server and clients
         /// </summary>
@@ -1075,7 +922,6 @@ namespace Dotmim.Sync.Tests
                 Assert.Equal(0, s.TotalChangesUploaded);
             }
         }
-
 
 
         /// <summary>

--- a/Tests/Dotmim.Sync.Tests/HttpTestsBase.cs
+++ b/Tests/Dotmim.Sync.Tests/HttpTestsBase.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading.Tasks;
+using Dotmim.Sync.Tests.Core;
+using Dotmim.Sync.Web.Server;
+using Microsoft.Data.SqlClient;
+using MySql.Data.MySqlClient;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Dotmim.Sync.Tests
+{
+
+    [TestCaseOrderer("Dotmim.Sync.Tests.Misc.PriorityOrderer", "Dotmim.Sync.Tests")]
+    public abstract class HttpTestsBase : IClassFixture<HelperProvider>, IDisposable
+    {
+        private Stopwatch stopwatch;
+
+        /// <summary>
+        /// Gets the sync tables involved in the tests
+        /// </summary>
+        public abstract string[] Tables { get; }
+
+        /// <summary>
+        /// Gets the clients type we want to tests
+        /// </summary>
+        public abstract List<ProviderType> ClientsType { get; }
+
+        /// <summary>
+        /// Gets the server type we want to test
+        /// </summary>
+        public abstract ProviderType ServerType { get; }
+
+        /// <summary>
+        /// Gets if fiddler is in use
+        /// </summary>
+        public abstract bool UseFiddler { get; }
+
+        /// <summary>
+        /// Service Uri provided by kestrell when starts
+        /// </summary>
+        public string ServiceUri { get; private set; }
+
+        /// <summary>
+        /// Gets the Web Server Orchestrator used for the tests
+        /// </summary>
+        public WebServerOrchestrator WebServerOrchestrator { get; private set; }
+
+        /// <summary>
+        /// Get the server rows count
+        /// </summary>
+        public abstract int GetServerDatabaseRowsCount((string DatabaseName, ProviderType ProviderType, CoreProvider Provider) t);
+
+        /// <summary>
+        /// Create a provider
+        /// </summary>
+        public abstract CoreProvider CreateProvider(ProviderType providerType, string dbName);
+
+        /// <summary>
+        /// Create database, seed it, with or without schema
+        /// </summary>
+        public abstract Task EnsureDatabaseSchemaAndSeedAsync((string DatabaseName,
+            ProviderType ProviderType, CoreProvider Provider) t, bool useSeeding = false, bool useFallbackSchema = false);
+
+
+        /// <summary>
+        /// Create an empty database
+        /// </summary>
+        public abstract Task CreateDatabaseAsync(ProviderType providerType, string dbName, bool recreateDb = true);
+
+
+        // abstract fixture used to run the tests
+        protected readonly HelperProvider fixture;
+
+        // Current test running
+        private ITest test;
+        private KestrellTestServer kestrell;
+
+
+        /// <summary>
+        /// Gets the remote orchestrator and its database name
+        /// </summary>
+        public (string DatabaseName, ProviderType ProviderType, CoreProvider Provider) Server { get; private set; }
+
+        /// <summary>
+        /// Gets the dictionary of all local orchestrators with database name as key
+        /// </summary>
+        public List<(string DatabaseName, ProviderType ProviderType, CoreProvider Provider)> Clients { get; set; }
+
+        /// <summary>
+        /// Gets a bool indicating if we should generate the schema for tables
+        /// </summary>
+        public bool UseFallbackSchema => ServerType == ProviderType.Sql;
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public HttpTestsBase(HelperProvider fixture, ITestOutputHelper output)
+        {
+
+            // Getting the test running
+            var type = output.GetType();
+            var testMember = type.GetField("test", BindingFlags.Instance | BindingFlags.NonPublic);
+            this.test = (ITest)testMember.GetValue(output);
+
+            this.stopwatch = Stopwatch.StartNew();
+
+            this.fixture = fixture;
+
+            // Since we are creating a lot of databases
+            // each database will have its own pool
+            // Droping database will not clear the pool associated
+            // So clear the pools on every start of a new test
+            SqlConnection.ClearAllPools();
+            MySqlConnection.ClearAllPools();
+
+            // get the server provider (and db created) without seed
+            var serverDatabaseName = HelperDatabase.GetRandomName("http_sv_");
+
+            var serverProvider = this.CreateProvider(this.ServerType, serverDatabaseName);
+
+            // create web remote orchestrator
+            this.WebServerOrchestrator = new WebServerOrchestrator(serverProvider, new SyncOptions(), new WebServerOptions(), new SyncSetup());
+
+            // public property
+            this.Server = (serverDatabaseName, this.ServerType, serverProvider);
+
+            // Create a kestrell server
+            this.kestrell = new KestrellTestServer(this.WebServerOrchestrator, this.UseFiddler);
+
+            // start server and get uri
+            this.ServiceUri = this.kestrell.Run();
+
+            // Get all clients providers
+            Clients = new List<(string, ProviderType, CoreProvider)>(this.ClientsType.Count);
+
+            // Generate Client database
+            foreach (var clientType in this.ClientsType)
+            {
+                var dbCliName = HelperDatabase.GetRandomName("http_cli_");
+                var localProvider = this.CreateProvider(clientType, dbCliName);
+                this.Clients.Add((dbCliName, clientType, localProvider));
+            }
+
+        }
+
+        /// <summary>
+        /// Drop all databases used for the tests
+        /// </summary>
+        public void Dispose()
+        {
+            //HelperDatabase.DropDatabase(this.ServerType, Server.DatabaseName);
+
+            //foreach (var client in Clients)
+            //{
+            //    HelperDatabase.DropDatabase(client.ProviderType, client.DatabaseName);
+            //}
+
+            this.kestrell.Dispose();
+
+            this.stopwatch.Stop();
+
+            var str = $"{test.TestCase.DisplayName} : {this.stopwatch.Elapsed.Minutes}:{this.stopwatch.Elapsed.Seconds}.{this.stopwatch.Elapsed.Milliseconds}";
+            Console.WriteLine(str);
+            Debug.WriteLine(str);
+
+        }
+    }
+
+}

--- a/Tests/Dotmim.Sync.Tests/IntegrationTests/SqlServer/SqlServerToSqliteTransactionTests.cs
+++ b/Tests/Dotmim.Sync.Tests/IntegrationTests/SqlServer/SqlServerToSqliteTransactionTests.cs
@@ -1,0 +1,243 @@
+﻿using Dotmim.Sync.MySql;
+using Dotmim.Sync.Sqlite;
+using Dotmim.Sync.SqlServer;
+using Dotmim.Sync.Tests.Core;
+using Dotmim.Sync.Tests.Models;
+using Dotmim.Sync.Web.Server;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Dotmim.Sync.Tests.Misc;
+using Dotmim.Sync.Web.Client;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.Sqlite;
+using MySql.Data.MySqlClient;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Dotmim.Sync.Tests.IntegrationTests
+{
+    public class SqlServerToSqliteTransactionTests : HttpTestsBase
+    {
+        private Stopwatch stopwatch;
+
+        public SqlServerToSqliteTransactionTests(HelperProvider fixture, ITestOutputHelper output) : base(fixture, output)
+        {
+        }
+
+        public override string[] Tables => new string[]
+        {
+            "SalesLT.ProductCategory", "SalesLT.ProductModel", "SalesLT.Product", "Employee", "Customer", "Address", "CustomerAddress", "EmployeeAddress",
+            "SalesLT.SalesOrderHeader", "SalesLT.SalesOrderDetail", "dbo.Sql", "Posts", "Tags", "PostTag",
+            "PricesList", "PricesListCategory", "PricesListDetail"
+        };
+
+        public override List<ProviderType> ClientsType => new List<ProviderType>
+            { ProviderType.Sqlite};
+
+        public override ProviderType ServerType => ProviderType.Sql;
+        
+        public override CoreProvider CreateProvider(ProviderType providerType, string dbName)
+        {
+            var cs = HelperDatabase.GetConnectionString(providerType, dbName);
+            switch (providerType)
+            {
+                case ProviderType.MySql:
+                    return new MySqlSyncProvider(cs);
+                case ProviderType.Sqlite:
+                    return new SqliteSyncProvider(cs);
+                case ProviderType.Sql:
+                default:
+                    return new SqlSyncProvider(cs);
+            }
+        }
+
+        public override bool UseFiddler => false;
+
+        public override async Task EnsureDatabaseSchemaAndSeedAsync((string DatabaseName, ProviderType ProviderType, CoreProvider Provider) t, bool useSeeding = false, bool useFallbackSchema = false)
+        {
+            AdventureWorksContext ctx = null;
+            try
+            {
+                ctx = new AdventureWorksContext(t, useFallbackSchema, useSeeding);
+                await ctx.Database.EnsureCreatedAsync();
+
+            }
+            catch (Exception)
+            {
+            }
+            finally
+            {
+                if (ctx != null)
+                    ctx.Dispose();
+            }
+        }
+
+        public override Task CreateDatabaseAsync(ProviderType providerType, string dbName, bool recreateDb = true)
+        {
+            return HelperDatabase.CreateDatabaseAsync(providerType, dbName, recreateDb);
+        }
+
+        /// <summary>
+        /// Get the server database rows count
+        /// </summary>
+        /// <returns></returns>
+        public override int GetServerDatabaseRowsCount((string DatabaseName, ProviderType ProviderType, CoreProvider Provider) t)
+        {
+            int totalCountRows = 0;
+
+            using (var serverDbCtx = new AdventureWorksContext(t))
+            {
+                totalCountRows += serverDbCtx.Address.Count();
+                totalCountRows += serverDbCtx.Customer.Count();
+                totalCountRows += serverDbCtx.CustomerAddress.Count();
+                totalCountRows += serverDbCtx.Employee.Count();
+                totalCountRows += serverDbCtx.EmployeeAddress.Count();
+                totalCountRows += serverDbCtx.Log.Count();
+                totalCountRows += serverDbCtx.Posts.Count();
+                totalCountRows += serverDbCtx.PostTag.Count();
+                totalCountRows += serverDbCtx.PricesList.Count();
+                totalCountRows += serverDbCtx.PricesListCategory.Count();
+                totalCountRows += serverDbCtx.PricesListDetail.Count();
+                totalCountRows += serverDbCtx.Product.Count();
+                totalCountRows += serverDbCtx.ProductCategory.Count();
+                totalCountRows += serverDbCtx.ProductModel.Count();
+                totalCountRows += serverDbCtx.SalesOrderDetail.Count();
+                totalCountRows += serverDbCtx.SalesOrderHeader.Count();
+                totalCountRows += serverDbCtx.Sql.Count();
+                totalCountRows += serverDbCtx.Tags.Count();
+            }
+
+            return totalCountRows;
+        }
+
+        /// <summary>
+        /// Note: This test basically ensures, that no other transaction can write to the database while the SqliteSyncProvider
+        /// retrieves the local changes. Otherwise, the local timestamp by those writes could be lower than the next sync timestamp.
+        /// Therefore, those rows would be ignored during the current sync and in **all** future syncs!
+        /// </summary>
+        /// <returns></returns>
+        [Fact, TestPriority(1)]
+        public async Task EnsureLocalSqliteProvier_DoesNotUseDeferredTransactions_WhenSelectingChanges()
+        {
+            // Arrange
+            var options = new SyncOptions { BatchSize = 100 };
+            await this.EnsureDatabaseSchemaAndSeedAsync(this.Server, true, UseFallbackSchema);
+            var client = Clients.Single();
+            await this.CreateDatabaseAsync(client.ProviderType, client.DatabaseName, true);
+
+            // configure server orchestrator
+            this.WebServerOrchestrator.Setup.Tables.AddRange(Tables);
+
+            // Get count of rows
+            var rowsCount = this.GetServerDatabaseRowsCount(this.Server);
+
+            var agent = new SyncAgent(client.Provider, new WebClientOrchestrator(this.ServiceUri), options);
+            var s = await agent.SynchronizeAsync();
+
+            Assert.Equal(rowsCount, s.TotalChangesDownloaded);
+            Assert.Equal(0, s.TotalChangesUploaded);
+            Assert.Equal(0, s.TotalResolvedConflicts);
+
+            var ev0 = new SemaphoreSlim(0, 1);
+            var ev1 = new SemaphoreSlim(0, 1);
+            var ev2 = new SemaphoreSlim(0, 1);
+            var ev3 = new SemaphoreSlim(0, 1);
+            var cts = new CancellationTokenSource(1000);
+
+            // create brand new client and setup locks
+            agent = new SyncAgent(client.Provider, new WebClientOrchestrator(this.ServiceUri), options);
+            agent.LocalOrchestrator.OnTableChangesSelecting((e) =>
+            {
+                ev1.Release();
+                ev2.Wait(cts.Token);
+            });
+            agent.LocalOrchestrator.OnTableChangesSelected(e =>
+            {
+                ev3.Release();
+            });
+
+            SyncResult t0Session = null;
+            var t0 = Task.Run(async () =>
+            {
+                await ev0.WaitAsync(cts.Token);
+                t0Session = await agent.SynchronizeAsync();
+            });
+
+            var t1 = Task.Run(async () =>
+            {
+                using (var c = new SqliteConnection(client.Provider.ConnectionString))
+                {
+                    ev0.Release();
+                    await ev1.WaitAsync(cts.Token);
+
+                    // Note: Without a timeout specified in cts, this next operation MUST deadlock
+                    // Otherwise, this means the SqliteSyncProvider uses a deferred transaction (since Microsoft.Data.Sqlite 5.0!)
+                    // see here: https://docs.microsoft.com/en-us/dotnet/standard/data/sqlite/transactions
+                    using (var tx = c.BeginTransaction())
+                    {
+                        var productId = Guid.NewGuid();
+                        InsertProduct(c, "locally added prod", productId, tx);
+
+                        var ts = ReadProductTimestamp(c, productId, tx);
+
+                        ev2.Release();
+                        await ev3.WaitAsync(cts.Token);
+
+                        tx.Commit();
+                    }
+                }
+            });
+            OperationCanceledException exception = null;
+
+            try
+            {
+                // Act
+                await Task.WhenAll(t0, t1);
+            }
+            catch (SyncException x)
+            {
+                exception = x.InnerException as OperationCanceledException;
+                
+            }
+
+            // Assert
+            Assert.NotNull(exception); // the operations MUSt be cancelled - otherwise the transaction will overlap - possibly because of BeginTransaction(deferred=true)!!
+        }
+
+        private static void InsertProduct(SqliteConnection c, string title, Guid productId, SqliteTransaction tx)
+        {
+            var uc = c.CreateCommand();
+            uc.Transaction = tx;
+            uc.CommandText = "insert into product (name, productid, productnumber, modifieddate) " +
+                             "values (@title, @id, @number, @creationtime)";
+            uc.Parameters.AddWithValue("title", title);
+            uc.Parameters.AddWithValue("id", productId);
+            uc.Parameters.AddWithValue("productnumber", productId.ToString("N"));
+            uc.Parameters.AddWithValue("creationtime", DateTime.UtcNow);
+            uc.ExecuteNonQuery();
+        }
+        private static async Task<(Guid id, long timestamp)> ReadProductTimestamp(SqliteConnection c, Guid productId, SqliteTransaction tx)
+        {
+            var rc = c.CreateCommand();
+            rc.Transaction = tx;
+            rc.CommandText = "select id, timestamp from product_tracking where productid = @id";
+            rc.Parameters.AddWithValue("id", productId);
+            var rcr = await rc.ExecuteReaderAsync();
+            if (rcr.Read())
+            {
+                var id = rcr.GetGuid(0);
+                var timestamp = rcr.GetInt64(1);
+                return (id, timestamp);
+            }
+
+            return (productId, 0);
+        }
+    }
+}


### PR DESCRIPTION
…e client sends additional batches


# 1 - solves data loss issue 

The issue is, that the `WebServerOrchestrator` just creates a new `clientBatchInfo` if it is null.
The issue with this is: If you send changes in batches and the server session is lost (e.g. due to an ApplicationPool recycle or because the Redis cache was cleared), it will just forget all the batches that were already sent during the ongoing session!



See the following sequencediagram for clarification:
```mermaid
sequenceDiagram
    participant Client
    participant Server
    loop GetLocalChanges
        Client->>Client: create 2 batch files (b0, b1, b2)
    end
    Client->>Server: Send b0
    Note right of Server: session is lost <br/>=> clientBatchInfo is null
    Client->>Server: Send b1
    Client->>Server: Send b2
    loop ApplyChanges
         Server->>Server: deserialize all batches and apply to database
         Note right of Server: Only inserts b1 and b2!<br/>b0 changes are forever lost!
    end

``` 

The only thing I had to add to fix this is a null-check:
```diff
            // ------------------------------------------------------------
            // FIRST STEP : receive client changes
            // ------------------------------------------------------------

+            // ensure that the blientBatchInfo is still available in the session - it **must** only be null when the batchIndex is 0!!
+            if (sessionCache.ClientBatchInfo == null && httpMessage.BatchIndex != 0)
+                throw new SyncException("Session loss: No batchPartInfo could found for the current sessionId. It seems the session was lost. Please try again.");

            // We are receiving changes from client
            // BatchInfo containing all BatchPartInfo objects
            // Retrieve batchinfo instance if exists
            // Get batch info from session cache if exists, otherwise create it
            if (sessionCache.ClientBatchInfo == null)
                sessionCache.ClientBatchInfo = new BatchInfo(clientWorkInMemory, Schema, this.Options.BatchDirectory);

```


Interestingly, your code **does** check whether the session is empty when the client is **requesting** additional batches.
So I just added a test to cover the fact that this will also not break in the future.




# 2 `HttpMessageSendChangesRequestArgs` takes a `byte[]` - what for?
I had to implement "OnReceiveChanges" interception
Why is the parameter `HttpMessageSendChangesRequestArgs` of `OnSendChanges` taking the binary data as a parameter?

I would argue, that when I do intercept this call, I would like to see what changes are sent.
But in the current implementation, I only do get a byte array.
The only thing I could think of was to manipulate this array to e.g. add another layer of compression/encryption. Is that the intention?
As I did not see any real sense in that, I removed this.
Instead (and also in order to create an integration test for this scenario) I changed the constructor to take a `HttpMessageSendChangesRequest` as a parameter instead of the `byte[]`:
```
public class HttpMessageSendChangesRequestArgs : ProgressArgs
    {
        public HttpMessageSendChangesRequestArgs(HttpMessageSendChangesRequest request) 
		{
			...
		}
	}

```

Likewhise, I had to add `HttpMessageSendChangesRequest` to the `HttpMessageSendChangesRequestArgs`

Additionally, the Interception happens **before** the changes are serialized.
That way, the interceptor can actually *modify* the changes sent to the server!

# 3 - Added integration test to ensure deferred transaction are never used by SqliteSyncProvider
Additionally, I added a specific integration test that ensures that the SqliteSyncProvider does **not** use deferred transactions when selecting local changes as this can also lead to data loss in the future!
