### PR TITLE
Minor fixes

### DIFF
--- a/Projects/Dotmim.Sync.Core/SyncResult.cs
+++ b/Projects/Dotmim.Sync.Core/SyncResult.cs
@@ -34,12 +34,12 @@ namespace Dotmim.Sync
         /// <summary>
         /// Gets the number of changes applied on the client
         /// </summary>
-        public int TotalChangesApplied => this.ChangesAppliedOnClient?.TotalAppliedChanges ?? 0) + (this.SnapshotChangesAppliedOnClient?.TotalAppliedChanges ?? 0;
+        public int TotalChangesApplied => (this.ChangesAppliedOnClient?.TotalAppliedChanges ?? 0) + (this.SnapshotChangesAppliedOnClient?.TotalAppliedChanges ?? 0);
 
         /// <summary>
         /// Gets total number of changes downloaded from server. 
         /// </summary>
-        public int TotalChangesDownloaded => this.ServerChangesSelected?.TotalChangesSelected ?? 0) + (this.SnapshotChangesAppliedOnClient?.TotalAppliedChanges ?? 0;
+        public int TotalChangesDownloaded => (this.ServerChangesSelected?.TotalChangesSelected ?? 0) + (this.SnapshotChangesAppliedOnClient?.TotalAppliedChanges ?? 0);
 
         /// <summary>
         /// Gets the number of change uploaded to the server

--- a/Projects/Dotmim.Sync.Core/SyncResult.cs
+++ b/Projects/Dotmim.Sync.Core/SyncResult.cs
@@ -34,23 +34,23 @@ namespace Dotmim.Sync
         /// <summary>
         /// Gets the number of changes applied on the client
         /// </summary>
-        public int TotalChangesApplied => this.ChangesAppliedOnClient.TotalAppliedChanges + (this.SnapshotChangesAppliedOnClient != null ? this.SnapshotChangesAppliedOnClient.TotalAppliedChanges : 0);
+        public int TotalChangesApplied => this.ChangesAppliedOnClient?.TotalAppliedChanges ?? 0) + (this.SnapshotChangesAppliedOnClient?.TotalAppliedChanges ?? 0;
 
         /// <summary>
         /// Gets total number of changes downloaded from server. 
         /// </summary>
-        public int TotalChangesDownloaded => this.ServerChangesSelected.TotalChangesSelected + (this.SnapshotChangesAppliedOnClient != null ? this.SnapshotChangesAppliedOnClient.TotalAppliedChanges : 0);
+        public int TotalChangesDownloaded => this.ServerChangesSelected?.TotalChangesSelected ?? 0) + (this.SnapshotChangesAppliedOnClient?.TotalAppliedChanges ?? 0;
 
         /// <summary>
         /// Gets the number of change uploaded to the server
         /// </summary>
-        public int TotalChangesUploaded => this.ClientChangesSelected.TotalChangesSelected;
+        public int TotalChangesUploaded => this.ClientChangesSelected?.TotalChangesSelected ?? 0;
 
         /// <summary>
         /// Gets the number of conflicts resolved
         /// </summary>
         public int TotalResolvedConflicts =>
-            Math.Max(this.ChangesAppliedOnClient.TotalResolvedConflicts, this.ChangesAppliedOnServer.TotalResolvedConflicts);
+            Math.Max(this.ChangesAppliedOnClient?.TotalResolvedConflicts ?? 0, this.ChangesAppliedOnServer?.TotalResolvedConflicts ?? 0);
 
         /// <summary>
         /// Gets the number of sync errors

--- a/Projects/Dotmim.Sync.Web.Client/WebClientOrchestrator.cs
+++ b/Projects/Dotmim.Sync.Web.Client/WebClientOrchestrator.cs
@@ -440,6 +440,8 @@ namespace Dotmim.Sync.Web.Client
 
                 changesSet.ImportContainerSet(summaryResponseContent.Changes, false);
 
+                AfterDeserializedRows(changesSet);
+
                 // Create a BatchPartInfo instance
                 await serverBatchInfo.AddChangesAsync(changesSet, 0, true, this.Options.SerializerFactory, this);
 
@@ -761,6 +763,8 @@ namespace Dotmim.Sync.Web.Client
                     DbSyncAdapter.CreateChangesTable(serverBatchInfo.SanitizedSchema.Tables[tbl.TableName, tbl.SchemaName], changesSet);
 
                 changesSet.ImportContainerSet(summaryResponseContent.Changes, false);
+
+                AfterDeserializedRows(changesSet);
 
                 // Create a BatchPartInfo instance
                 await serverBatchInfo.AddChangesAsync(changesSet, 0, true, this.Options.SerializerFactory, this);

--- a/Projects/Dotmim.Sync.Web.Client/WebClientOrchestrator.cs
+++ b/Projects/Dotmim.Sync.Web.Client/WebClientOrchestrator.cs
@@ -440,7 +440,9 @@ namespace Dotmim.Sync.Web.Client
 
                 changesSet.ImportContainerSet(summaryResponseContent.Changes, false);
 
-                AfterDeserializedRows(changesSet);
+
+                if (this.Converter != null)
+                    AfterDeserializedRows(changesSet);
 
                 // Create a BatchPartInfo instance
                 await serverBatchInfo.AddChangesAsync(changesSet, 0, true, this.Options.SerializerFactory, this);
@@ -764,7 +766,8 @@ namespace Dotmim.Sync.Web.Client
 
                 changesSet.ImportContainerSet(summaryResponseContent.Changes, false);
 
-                AfterDeserializedRows(changesSet);
+                if (this.Converter != null)
+                    AfterDeserializedRows(changesSet);
 
                 // Create a BatchPartInfo instance
                 await serverBatchInfo.AddChangesAsync(changesSet, 0, true, this.Options.SerializerFactory, this);

--- a/Projects/Dotmim.Sync.Web.Server/WebServerOrchestrator.cs
+++ b/Projects/Dotmim.Sync.Web.Server/WebServerOrchestrator.cs
@@ -101,6 +101,8 @@ namespace Dotmim.Sync.Web.Server
                 // if Hash is present in header, check hash
                 if (TryGetHeaderValue(context.Request.Headers, "dotmim-sync-hash", out string hashStringRequest))
                     HashAlgorithm.SHA256.EnsureHash(readableStream, hashStringRequest);
+                else
+                    readableStream.Seek(0, SeekOrigin.Begin);
 
                 // try get schema from cache
                 if (this.Cache.TryGetValue<SyncSet>(scopeName, out var cachedSchema))


### PR DESCRIPTION
Fixes in RyncResults that may cause debug errors because NullReferenceException
AfterDeserializedRows was not called while HTTP-sync
Correct sync on server in case there is not body hash in request headers
