### PR TITLE
Fix issue in sql change tracking when columns are updated that are not in the setup

### DIFF
--- a/Projects/Dotmim.Sync.Core/Setup/SyncSetup.cs
+++ b/Projects/Dotmim.Sync.Core/Setup/SyncSetup.cs
@@ -89,6 +89,10 @@ namespace Dotmim.Sync
         /// </summary>
         public bool HasColumns => this.Tables?.SelectMany(t => t.Columns).Count() > 0;  // using SelectMany to get columns and not Collection<Column>
 
+        /// <summary>
+        /// Check if Setup has a table that has columns
+        /// </summary>
+        public bool HasTableWithColumns(string tableName) => this.Tables[tableName]?.Columns?.Count > 0;
 
         /// <summary>
         /// Check if two setups have the same local options

--- a/Projects/Dotmim.Sync.SqlServer.ChangeTracking/Builders/SqlChangeTrackingBuilderProcedure.cs
+++ b/Projects/Dotmim.Sync.SqlServer.ChangeTracking/Builders/SqlChangeTrackingBuilderProcedure.cs
@@ -175,8 +175,10 @@ namespace Dotmim.Sync.SqlServer.ChangeTracking.Builders
                 stringBuilder.AppendLine($"SET IDENTITY_INSERT {tableName.Schema().Quoted().ToString()} ON;");
                 stringBuilder.AppendLine();
             }
-
-            stringBuilder.AppendLine("DECLARE @next_sync_min_timestamp bigint = @sync_min_timestamp + 1;");
+            if (setupHasTableWithColumns)
+            {
+                stringBuilder.AppendLine("DECLARE @next_sync_min_timestamp bigint = @sync_min_timestamp + 1;");
+            }
             stringBuilder.AppendLine("DECLARE @var_sync_scope_id varbinary(128) = cast(@sync_scope_id as varbinary(128));");
             stringBuilder.AppendLine();
             stringBuilder.AppendLine(";WITH ");
@@ -486,8 +488,10 @@ namespace Dotmim.Sync.SqlServer.ChangeTracking.Builders
                 stringBuilder.AppendLine($"SET IDENTITY_INSERT {tableName.Schema().Quoted().ToString()} ON;");
                 stringBuilder.AppendLine();
             }
-
-            stringBuilder.AppendLine("DECLARE @next_sync_min_timestamp bigint = @sync_min_timestamp + 1;");
+            if (setupHasTableWithColumns)
+            {
+                stringBuilder.AppendLine("DECLARE @next_sync_min_timestamp bigint = @sync_min_timestamp + 1;");
+            }
             stringBuilder.AppendLine("DECLARE @var_sync_scope_id varbinary(128) = cast(@sync_scope_id as varbinary(128));");
             stringBuilder.AppendLine();
 
@@ -731,10 +735,12 @@ namespace Dotmim.Sync.SqlServer.ChangeTracking.Builders
                 CreateFilterParameters(sqlCommand, filter);
 
             var stringBuilder = new StringBuilder("");
-            stringBuilder.AppendLine("DECLARE @next_sync_min_timestamp bigint = @sync_min_timestamp + 1;");
-            stringBuilder.AppendLine("DECLARE @var_sync_scope_id varbinary(128) = cast(@sync_scope_id as varbinary(128));");
-            stringBuilder.AppendLine();
-            stringBuilder.AppendLine("WITH ");
+            if (setupHasTableWithColumns)
+            {
+                stringBuilder.AppendLine("DECLARE @next_sync_min_timestamp bigint = @sync_min_timestamp + 1;");
+                stringBuilder.AppendLine();
+            }
+            stringBuilder.AppendLine(";WITH ");
             stringBuilder.AppendLine($"  {trackingName.Quoted().ToString()} AS (");
             stringBuilder.Append("\tSELECT ");
             foreach (var pkColumn in this.tableDescription.GetPrimaryKeysColumns())

--- a/Projects/Dotmim.Sync.SqlServer.ChangeTracking/Builders/SqlChangeTrackingBuilderProcedure.cs
+++ b/Projects/Dotmim.Sync.SqlServer.ChangeTracking/Builders/SqlChangeTrackingBuilderProcedure.cs
@@ -193,10 +193,11 @@ namespace Dotmim.Sync.SqlServer.ChangeTracking.Builders
             stringBuilder.AppendLine();
             stringBuilder.AppendLine("\tCAST([CT].[SYS_CHANGE_CONTEXT] AS uniqueidentifier) AS [sync_update_scope_id],");
             stringBuilder.AppendLine("\t[CT].[SYS_CHANGE_VERSION] AS [sync_timestamp],");
-            stringBuilder.Append("\t[CT].[SYS_CHANGE_OPERATION] AS [sync_change_operation]");
+            stringBuilder.Append("\tCASE WHEN [CT].[SYS_CHANGE_OPERATION] = 'D' THEN 1 ELSE 0 END AS [sync_row_is_tombstone]");
             if (setupHasTableWithColumns)
             {
-                stringBuilder.AppendLine(",\n\t-- select the next changed columns when the change operation was an insert");
+                stringBuilder.AppendLine(",\n\t[CT].[SYS_CHANGE_OPERATION] AS [sync_change_operation],");
+                stringBuilder.AppendLine("\t-- select the next changed columns when the change operation was an insert");
                 stringBuilder.AppendLine("\t(CASE WHEN [SYS_CHANGE_OPERATION] = 'I' THEN (");
                 stringBuilder.AppendLine("\t\tSELECT [N].[SYS_CHANGE_COLUMNS]");
                 stringBuilder.AppendLine($"\t\tFROM CHANGETABLE(CHANGES {tableName.Schema().Quoted().ToString()}, @next_sync_min_timestamp) AS [N]");
@@ -510,10 +511,11 @@ namespace Dotmim.Sync.SqlServer.ChangeTracking.Builders
             stringBuilder.AppendLine();
             stringBuilder.AppendLine("\tCAST([CT].[SYS_CHANGE_CONTEXT] as uniqueidentifier) AS [sync_update_scope_id],");
             stringBuilder.AppendLine("\t[CT].[SYS_CHANGE_VERSION] AS [sync_timestamp],");
-            stringBuilder.Append("\t[CT].[SYS_CHANGE_OPERATION] AS [sync_change_operation]");
+            stringBuilder.Append("\tCASE WHEN [CT].[SYS_CHANGE_OPERATION] = 'D' THEN 1 ELSE 0 END AS [sync_row_is_tombstone]");
             if (setupHasTableWithColumns)
             {
-                stringBuilder.AppendLine(",\n\t-- select the next changed columns when the change operation was an insert");
+                stringBuilder.AppendLine(",\n\t[CT].[SYS_CHANGE_OPERATION] AS [sync_change_operation],");
+                stringBuilder.AppendLine("\t-- select the next changed columns when the change operation was an insert");
                 stringBuilder.AppendLine("\t(CASE WHEN [SYS_CHANGE_OPERATION] = 'I' THEN (");
                 stringBuilder.AppendLine("\t\tSELECT [N].[SYS_CHANGE_COLUMNS]");
                 stringBuilder.AppendLine($"\t\tFROM CHANGETABLE(CHANGES {tableName.Schema().Quoted().ToString()}, @next_sync_min_timestamp) AS [N]");
@@ -751,10 +753,11 @@ namespace Dotmim.Sync.SqlServer.ChangeTracking.Builders
             stringBuilder.AppendLine();
             stringBuilder.AppendLine("\tCAST([CT].[SYS_CHANGE_CONTEXT] AS uniqueidentifier) AS [sync_update_scope_id],");
             stringBuilder.AppendLine("\t[CT].[SYS_CHANGE_VERSION] AS [sync_timestamp],");
-            stringBuilder.Append("\t[CT].[SYS_CHANGE_OPERATION] AS [sync_change_operation]");
+            stringBuilder.Append("\tCASE WHEN [CT].[SYS_CHANGE_OPERATION] = 'D' THEN 1 ELSE 0 END AS [sync_row_is_tombstone]");
             if (setupHasTableWithColumns)
             {
-                stringBuilder.AppendLine(",\n\t-- select the next changed columns when the change operation was an insert");
+                stringBuilder.AppendLine(",\n\t[CT].[SYS_CHANGE_OPERATION] AS [sync_change_operation],");
+                stringBuilder.AppendLine("\t-- select the next changed columns when the change operation was an insert");
                 stringBuilder.AppendLine("\t(CASE WHEN [SYS_CHANGE_OPERATION] = 'I' THEN (");
                 stringBuilder.AppendLine("\t\tSELECT [N].[SYS_CHANGE_COLUMNS]");
                 stringBuilder.AppendLine($"\t\tFROM CHANGETABLE(CHANGES {tableName.Schema().Quoted().ToString()}, @next_sync_min_timestamp) AS [N]");
@@ -783,7 +786,7 @@ namespace Dotmim.Sync.SqlServer.ChangeTracking.Builders
                 var columnName = ParserName.Parse(mutableColumn).Quoted().ToString();
                 stringBuilder.AppendLine($"\t[base].{columnName},");
             }
-            stringBuilder.AppendLine("\tCASE WHEN [side].[sync_change_operation] = 'D' THEN 1 ELSE 0 END AS [sync_row_is_tombstone],");
+            stringBuilder.AppendLine("\t[side].[sync_row_is_tombstone],");
             stringBuilder.AppendLine("\t[side].[sync_update_scope_id]");
             stringBuilder.AppendLine($"FROM {tableName.Schema().Quoted().ToString()} [base]");
             stringBuilder.Append($"RIGHT JOIN {trackingName.Quoted().ToString()} [side]");

--- a/Projects/Dotmim.Sync.SqlServer.ChangeTracking/Builders/SqlChangeTrackingBuilderTrackingTable.cs
+++ b/Projects/Dotmim.Sync.SqlServer.ChangeTracking/Builders/SqlChangeTrackingBuilderTrackingTable.cs
@@ -1,17 +1,6 @@
 ﻿using Dotmim.Sync.Builders;
-
-
-
-using Dotmim.Sync.SqlServer.Builders;
 using Dotmim.Sync.SqlServer.Manager;
-using System;
-using System.Collections.Generic;
-using System.Data;
 using System.Data.Common;
-using Microsoft.Data.SqlClient;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Dotmim.Sync.SqlServer.ChangeTracking.Builders
@@ -24,7 +13,6 @@ namespace Dotmim.Sync.SqlServer.ChangeTracking.Builders
         private readonly SyncSetup setup;
         private readonly SqlDbMetadata sqlDbMetadata;
 
-    
         public SqlChangeTrackingBuilderTrackingTable(SyncTable tableDescription, ParserName tableName, ParserName trackingName, SyncSetup setup)
         {
             this.tableDescription = tableDescription;
@@ -65,15 +53,21 @@ namespace Dotmim.Sync.SqlServer.ChangeTracking.Builders
             return Task.FromResult(command);
         }
 
-
         public Task<DbCommand> GetCreateTrackingTableCommandAsync(DbConnection connection, DbTransaction transaction)
         {
-            var commandText = $"ALTER TABLE {tableName.Schema().Quoted().ToString()} ENABLE CHANGE_TRACKING WITH(TRACK_COLUMNS_UPDATED = OFF);";
-
             var command = connection.CreateCommand();
+
+            if (setup.HasTableWithColumns(tableDescription.TableName))
+            {
+                command.CommandText = $"ALTER TABLE {tableName.Schema().Quoted().ToString()} ENABLE CHANGE_TRACKING WITH(TRACK_COLUMNS_UPDATED = ON);";
+            }
+            else
+            {
+                command.CommandText = $"ALTER TABLE {tableName.Schema().Quoted().ToString()} ENABLE CHANGE_TRACKING WITH(TRACK_COLUMNS_UPDATED = OFF);";
+            }
+
             command.Connection = connection;
             command.Transaction = transaction;
-            command.CommandText = commandText;
 
             return Task.FromResult(command);
         }
@@ -90,7 +84,7 @@ namespace Dotmim.Sync.SqlServer.ChangeTracking.Builders
             return Task.FromResult(command);
         }
 
-        public Task<DbCommand> GetRenameTrackingTableCommandAsync(ParserName oldTableName, DbConnection connection, DbTransaction transaction) 
+        public Task<DbCommand> GetRenameTrackingTableCommandAsync(ParserName oldTableName, DbConnection connection, DbTransaction transaction)
             => Task.FromResult<DbCommand>(null);
     }
 }

--- a/Tests/Dotmim.Sync.Tests/IntegrationTests/SqlServerChangeTracking/SqlServerChangeTrackingTcpTests.cs
+++ b/Tests/Dotmim.Sync.Tests/IntegrationTests/SqlServerChangeTracking/SqlServerChangeTrackingTcpTests.cs
@@ -1,20 +1,16 @@
 ﻿
+using Dotmim.Sync.MariaDB;
 using Dotmim.Sync.MySql;
 using Dotmim.Sync.Sqlite;
 using Dotmim.Sync.SqlServer;
 using Dotmim.Sync.Tests.Core;
 using Dotmim.Sync.Tests.Models;
-using Dotmim.Sync.Web.Server;
-using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Data.SqlClient;
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.SqlClient;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Xunit;
 using Xunit.Abstractions;
-using Dotmim.Sync.MariaDB;
 
 namespace Dotmim.Sync.Tests.IntegrationTests
 {
@@ -177,7 +173,6 @@ namespace Dotmim.Sync.Tests.IntegrationTests
             return totalCountRows;
         }
 
-
         /// <summary>
         /// Since we do not have control on the change tracking mechanism, any row updated will be marked as updated
         /// Even if the value is the same or if the column is not part of sync setup
@@ -186,23 +181,5 @@ namespace Dotmim.Sync.Tests.IntegrationTests
         {
             return Task.CompletedTask;
         }
-
-        /// <summary>
-        /// Since we do not have control on the change tracking mechanism, any row updated will be marked as updated
-        /// Even if the value is the same or if the column is not part of sync setup
-        /// </summary>
-        public override Task OneColumn_NotInSetup_ShouldNotBe_UploadToServer(SyncOptions options) {
-            return Task.CompletedTask;
-        }
-
-        /// <summary>
-        /// Since we do not have control on the change tracking mechanism, any row updated will be marked as updated
-        /// Even if the value is the same or if the column is not part of sync setup
-        /// </summary>
-        public override Task OneColumn_NotInSetup_IfServerSendsChanges_UpdatesLocalRow_AndDoesNotClear_OneColumn(SyncOptions options)
-        {
-            return Task.CompletedTask;
-        }
-
     }
 }


### PR DESCRIPTION
The behaviour should be that when the sync setup contains columns, only those columns should be involved in the sync.