### PR TITLE
Exception in SqlSyncAdapter.cs. Remove DateTimeOffset conversion and handle SmallDateTime better

### DIFF
--- a/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
@@ -28,6 +28,7 @@ namespace Dotmim.Sync.SqlServer.Builders
 
         public static DateTime SqlDateMin = new DateTime(1753, 1, 1);
 
+        public static DateTime SqlSmallDateMin = new DateTime(1900, 1, 1);
         public SqlObjectNames SqlObjectNames { get; set; }
         public SqlDbMetadata SqlMetadata { get; set; }
 
@@ -169,14 +170,14 @@ namespace Dotmim.Sync.SqlServer.Builders
                                 case SqlDbType.SmallDateTime:
                                     if (columnType != typeof(DateTime))
                                         rowValue = SyncTypeConverter.TryConvertTo<DateTime>(rowValue);
-                                    if (rowValue < SqlDateMin)
+                                    if (sqlMetadataType == SqlDbType.DateTime && rowValue < SqlDateMin)
                                         rowValue = SqlDateMin;
+                                    if (sqlMetadataType == SqlDbType.SmallDateTime && rowValue < SqlSmallDateMin)
+                                        rowValue = SqlSmallDateMin;
                                     break;
                                 case SqlDbType.DateTimeOffset:
                                     if (columnType != typeof(DateTimeOffset))
                                         rowValue = SyncTypeConverter.TryConvertTo<DateTimeOffset>(rowValue);
-                                    if (rowValue < SqlDateMin)
-                                        rowValue = SqlDateMin;
                                     break;
                                 case SqlDbType.Decimal:
                                     if (columnType != typeof(decimal))


### PR DESCRIPTION
Changing the value of DateTimeOffset when the rowValue < SqlDateMin throws exception when record.SetValue is called because the types are different.  There is no reason to be changing the data on DateTimeOffset since it can handle values lower than SqlDateMin.  Only DateTime & SmallDateTime have limits so I also adjusted the code to handle those.

Closes #680 