### PR TITLE
Update session end to contain SyncResult

### DIFF
--- a/Projects/Dotmim.Sync.Core/Args/SessionArgs.cs
+++ b/Projects/Dotmim.Sync.Core/Args/SessionArgs.cs
@@ -131,9 +131,15 @@ namespace Dotmim.Sync
     /// </summary>
     public class SessionEndArgs : ProgressArgs
     {
-        public SessionEndArgs(SyncContext context, DbConnection connection)
+        /// <summary>
+        /// Gets the sync result
+        /// </summary>
+        public SyncResult SyncResult { get; }
+
+        public SessionEndArgs(SyncContext context, SyncResult syncResult, DbConnection connection)
             : base(context, connection, null)
         {
+            SyncResult = syncResult;
         }
         public override SyncProgressLevel ProgressLevel => SyncProgressLevel.Information;
         public override string Source => Connection.Database;

--- a/Projects/Dotmim.Sync.Core/Orchestrators/LocalOrchestrator.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/LocalOrchestrator.cs
@@ -65,25 +65,25 @@ namespace Dotmim.Sync
         /// <summary>
         /// Called when the sync is over
         /// </summary>
-        public Task EndSessionAsync(string scopeName = SyncOptions.DefaultScopeName, CancellationToken cancellationToken = default, IProgress<ProgressArgs> progress = null)
+        public Task EndSessionAsync(SyncResult syncResult, string scopeName = SyncOptions.DefaultScopeName, CancellationToken cancellationToken = default, IProgress<ProgressArgs> progress = null)
         {
             // Create a new context
             var ctx = new SyncContext(Guid.NewGuid(), scopeName);
 
-            return InternalEndSessionAsync(ctx, cancellationToken, progress);
+            return InternalEndSessionAsync(ctx, syncResult, cancellationToken, progress);
         }
 
         /// <summary>
         /// Called when the sync is over
         /// </summary>
-        public async Task<SyncContext> InternalEndSessionAsync(SyncContext context, CancellationToken cancellationToken = default, IProgress<ProgressArgs> progress = null)
+        public async Task<SyncContext> InternalEndSessionAsync(SyncContext context, SyncResult result, CancellationToken cancellationToken = default, IProgress<ProgressArgs> progress = null)
         {
             context.SyncStage = SyncStage.EndSession;
 
             var connection = this.Provider.CreateConnection();
 
             // Progress & interceptor
-            await this.InterceptAsync(new SessionEndArgs(context, connection), progress, cancellationToken).ConfigureAwait(false);
+            await this.InterceptAsync(new SessionEndArgs(context, result, connection), progress, cancellationToken).ConfigureAwait(false);
 
             return context;
         }

--- a/Projects/Dotmim.Sync.Core/SyncAgent.cs
+++ b/Projects/Dotmim.Sync.Core/SyncAgent.cs
@@ -410,9 +410,9 @@ namespace Dotmim.Sync
                 result.ChangesAppliedOnClient = clientChangesApplied.ChangesApplied;
                 result.ChangesAppliedOnServer = serverChangesApplied;
 
-                // Begin session
+                // End session
                 context.ProgressPercentage = 1;
-                context = await this.LocalOrchestrator.InternalEndSessionAsync(context, cancellationToken, progress).ConfigureAwait(false);
+                context = await this.LocalOrchestrator.InternalEndSessionAsync(context, result, cancellationToken, progress).ConfigureAwait(false);
 
                 if (cancellationToken.IsCancellationRequested)
                     cancellationToken.ThrowIfCancellationRequested();
@@ -565,9 +565,9 @@ namespace Dotmim.Sync
 
                 result.CompleteTime = completeTime;
 
-                // Begin session
+                // End session
                 context.ProgressPercentage = 1;
-                await this.LocalOrchestrator.EndSessionAsync(scopeName, cancellationToken, progress).ConfigureAwait(false);
+                await this.LocalOrchestrator.EndSessionAsync(result, scopeName, cancellationToken, progress).ConfigureAwait(false);
 
                 if (cancellationToken.IsCancellationRequested)
                     cancellationToken.ThrowIfCancellationRequested();

--- a/Tests/Dotmim.Sync.Tests/UnitTests/Orchestrators/LocalOrchestrator.Tests.cs
+++ b/Tests/Dotmim.Sync.Tests/UnitTests/Orchestrators/LocalOrchestrator.Tests.cs
@@ -99,7 +99,7 @@ namespace Dotmim.Sync.Tests.UnitTests
                 onSessionEnd = true;
             });
 
-            await localOrchestrator.EndSessionAsync(SyncOptions.DefaultScopeName);
+            await localOrchestrator.EndSessionAsync(new SyncResult(), SyncOptions.DefaultScopeName);
 
             Assert.True(onSessionEnd);
         }


### PR DESCRIPTION
Added SyncResult to the 'SessionEndArgs' because it's not possible to get the SyncResult in relation to the SyncContext like before.  The SyncContext is now being passed around everywhere and doesn't exist as GetContext() on the 'WebRemoteOrchestrator' anymore.  Adding this to the SessionEnd allows users to intercept the event and perform custom operations on the SyncResult in relation to the SyncContext such as a custom session ended event which inserts statistics into a custom tables based on the sync scope id which exists on the context.