### PR TITLE
[Dotmim.Sync.MySql] Optimize update trigger

### DIFF
--- a/Projects/Dotmim.Sync.MySql/Builders/MySqlBuilderTrigger.cs
+++ b/Projects/Dotmim.Sync.MySql/Builders/MySqlBuilderTrigger.cs
@@ -265,13 +265,13 @@ namespace Dotmim.Sync.MySql.Builders
             var filterColumnsString3 = new StringBuilder();
 
             createTrigger.AppendLine("\t) ");
-            createTrigger.AppendLine("\tSELECT ");
+            createTrigger.AppendLine("\tVALUES (");
             createTrigger.Append(stringBuilderArguments2.ToString());
             createTrigger.AppendLine("\t\t,NULL");
             createTrigger.AppendLine($"\t\t,{this.timestampValue}");
             createTrigger.AppendLine("\t\t,0");
             createTrigger.AppendLine("\t\t,utc_timestamp()");
-            createTrigger.AppendLine($"\tFROM {tableName.Quoted().ToString()}"); //[AB] added to be compatible with MariaDB 10.3.x
+            createTrigger.AppendLine("\t)");
 
             //if (this.tableDescription.GetMutableColumns().Count() > 0)
             //{


### PR DESCRIPTION
## Affected packages
- Dotmim.Sync.MariaDB
- Dotmim.Sync.MySql

## Description

`INSERT ... ON DUPLICATE KEY UPDATE ...` statement for adding new tracking row to tracking table is executed for **N** rows instead of 1. Where: 
- **N** is number of rows in table that is tracked,
- Each row have the same values.  Values part uses only `new.{pk_column}` and `utc_timestamp()`.
Resulting in one insert and **N-1** updates.

It causes:
- huge performance issues for first update of not yet tracked table row,
- mysql `Lock wait timeout exceeded` errors when concurrent updates occur.

when provisioned for existing table, that has:
- multiple-column primary key which is not optimized,
- over 500'000 rows.

See [Background](#background) for more detail.

## Bug resolution

Use `INSERT INTO ... VALUES ...` instead of  `INSERT INTO ... SELECT ...`.

Before:
```mysql
INSERT INTO {tableName}_tracking 
SELECT ... 
FROM {tableName} 
ON DUPLICATE KEY UPDATE (...)
```

After:
```mysql
INSERT INTO {tableName}_tracking 
VALUES (...)
ON DUPLICATE KEY UPDATE (...)
```

## Consequences of the fix 

Fix changes content of the trigger definition, so the trigger needs to updated in existing tables.

Posible solutions:
1. Package users must run `ProvisionAsync` with `overwrite=true`,
2. Add trigger update to upgrade method to not yet released version (not included in PR).

## Background

<details>

### 1. Version 0.6.2 mysql update trigger  ([diff](https://github.com/Mimetis/Dotmim.Sync/commit/cf8f47ba4d01ab83f34d03ef8d9901468e83145c#diff-c9e5497973710b931e751875b9362d3a31fcf828d2e699ef0efe8726401090a2R252))

Introduced `WHERE` clause for conditional insertion in update trigger.

Before: 
```mysql
INSERT INTO {tableName}_tracking 
VALUES (...)
ON DUPLICATE KEY UPDATE (...)
```

After:
```mysql 
INSERT INTO {tableName}_tracking 
SELECT (...) WHERE (...) # WHERE clause uses values from `new`.
ON DUPLICATE KEY UPDATE (...)
```

### 2. Fix for MariaDB 10.3  ([diff](https://github.com/Mimetis/Dotmim.Sync/pull/694/commits/89ac0b1fa1ef64c8669c1d2589bf55ba36edae44#diff-c9e5497973710b931e751875b9362d3a31fcf828d2e699ef0efe8726401090a2R272))

Pull request #694.

Added `FROM {tableName}` to `INSERT` statement, which introduced performance degradation.
Before the `SELECT` statement result was for zero or one row based on `WHERE` clause.
After the `SELECT` statement result was number of original table rows (even though each result row is the same).

Performance issues could be observed during update of row from table, for which there is no tracking row.

Before:
```mysql
INSERT INTO {name}_tracking 
SELECT (...) 
WHERE (...) 
ON DUPLICATE KEY UPDATE (...)
``` 

After:
```mysql
INSERT INTO {tableName}_tracking 
SELECT ... 
FROM {tableName} 
WHERE (...)
ON DUPLICATE KEY UPDATE (...)
```

### 3. Version 0.9.5 stopped using conditional insertion to tracking table ([diff](https://github.com/Mimetis/Dotmim.Sync/commit/fad22539a63758d9267397fa12e87fdfab60348a#diff-c9e5497973710b931e751875b9362d3a31fcf828d2e699ef0efe8726401090a2R276))

Version `0.9.5` simplified statements in MySQL triggers by removing conditional insertion of tracking row (`WHERE` clause is not used anymore in `INSERT INTO`).

From now on, the `SELECT` statement results count is equal number of table rows.

Before: 
```mysql
INSERT INTO {name}_tracking 
SELECT (...) 
FROM {tableName}
WHERE (...) 
ON DUPLICATE KEY UPDATE (...)
``` 
After:
```mysql
INSERT INTO {tableName}_tracking 
SELECT ... 
FROM {tableName}
ON DUPLICATE KEY UPDATE (...)
```

</details>