### PR TITLE
fix: Linker error on Xamarin

### DIFF
--- a/Projects/Dotmim.Sync.Web.Client/Dotmim.Sync.Web.Client.csproj
+++ b/Projects/Dotmim.Sync.Web.Client/Dotmim.Sync.Web.Client.csproj
@@ -47,7 +47,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
+		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\Dotmim.Sync.Core\Dotmim.Sync.Core.csproj" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>

--- a/Projects/Dotmim.Sync.Web.Client/HttpRequestHandler.cs
+++ b/Projects/Dotmim.Sync.Web.Client/HttpRequestHandler.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using Microsoft.Net.Http.Headers;
 using System.Net.Http.Headers;
 
 namespace Dotmim.Sync.Web.Client
@@ -133,14 +132,9 @@ namespace Dotmim.Sync.Web.Client
             // var cookieList = response.Headers.GetValues("Set-Cookie").ToList();
             if (cookieList != null && cookieList.Count > 0)
             {
-#if NETSTANDARD
-                // Get the first cookie
-                this.Cookie = CookieHeaderValue.ParseList(cookieList).FirstOrDefault();
-#else
                 //try to parse the very first cookie
                 if (CookieHeaderValue.TryParse(cookieList[0], out var cookie))
                     this.Cookie = cookie;
-#endif
             }
         }
 


### PR DESCRIPTION
Fix Xamarin Form Build in Release mode when add reference to `Microsoft.EntityFrameworkCore.Sqlite >= 5.0.17` and `Dotmim.Sync.Web.Client 0.9.7`

`Microsoft.EntityFrameworkCore.Sqlite` required `Microsoft.Extensions.Primitives (>= 5.0.0)`
`Microsoft.Net.Http.Headers` required `Microsoft.Extensions.Primitives (>= 2.2.0)`

Nuget resolve dependecy using  `Microsoft.Extensions.Primitives 5.0.1` but when build in release mode linker 
throw 
```
Mono.Linker.MarkException: Error processing method: 'System.String Microsoft.Net.Http.Headers.DateTimeFormatter::ToRfc1123String(System.DateTimeOffset,System.Boolean)' in assembly: 'Microsoft.Net.Http.Headers.dll' ---> Mono.Cecil.ResolutionException: Failed to resolve Microsoft.Extensions.Primitives.InplaceStringBuilder
```
because `Microsoft.Extensions.Primitives.InplaceStringBuilder` is removed from `Microsoft.Extensions.Primitives (>= 5.0.0)`

There is a workaround by forcing the downgrade to  `Microsoft.Extensions.Primitives 3.1.31` but it could lead to other problems.

https://github.com/dotnet/aspnetcore/issues/29062
