### PR TITLE
Fix inconsistent parameter naming between AddParameter methods

### DIFF
--- a/Projects/Dotmim.Sync.Core/Setup/SetupFilter.cs
+++ b/Projects/Dotmim.Sync.Core/Setup/SetupFilter.cs
@@ -65,6 +65,7 @@ namespace Dotmim.Sync
 
         /// <summary>
         /// Add a parameter as input to stored procedure
+        /// <paramref name="parameterName" /> can be anything and later used to compare to a column of the same type with <see cref="AddWhere"/>
         /// For SQL Server, parameter will be added as @{parameterName}
         /// For MySql, parameter will be added as in_{parameterName}
         /// </summary>
@@ -81,6 +82,7 @@ namespace Dotmim.Sync
 
         /// <summary>
         /// Add a parameter based on a column. 
+        /// <paramref name="columnName" /> refers to both the name of the parameter and column
         /// For SQL Server, parameter will be added as @{parameterName}
         /// For MySql, parameter will be added as in_{parameterName}
         /// </summary>
@@ -96,6 +98,7 @@ namespace Dotmim.Sync
 
         /// <summary>
         /// Add a parameter based on a column. 
+        /// <paramref name="columnName" /> refers to both the name of the parameter and column
         /// For SQL Server, parameter will be added as @{parameterName}
         /// For MySql, parameter will be added as in_{parameterName}
         /// </summary>

--- a/Projects/Dotmim.Sync.Core/Setup/SetupFilter.cs
+++ b/Projects/Dotmim.Sync.Core/Setup/SetupFilter.cs
@@ -84,13 +84,13 @@ namespace Dotmim.Sync
         /// For SQL Server, parameter will be added as @{parameterName}
         /// For MySql, parameter will be added as in_{parameterName}
         /// </summary>
-        public void AddParameter(string parameterName, string tableName, string schemaName, bool allowNull = false, string defaultValue = null)
+        public void AddParameter(string columnName, string tableName, string schemaName, bool allowNull = false, string defaultValue = null)
         {
 
-            if (this.Parameters.Any(p => string.Equals(p.Name, parameterName, SyncGlobalization.DataSourceStringComparison)))
-                throw new FilterParameterAlreadyExistsException(parameterName, this.TableName);
+            if (this.Parameters.Any(p => string.Equals(p.Name, columnName, SyncGlobalization.DataSourceStringComparison)))
+                throw new FilterParameterAlreadyExistsException(columnName, this.TableName);
 
-            this.Parameters.Add(new SetupFilterParameter { Name = parameterName, TableName = tableName, SchemaName = schemaName, DefaultValue = defaultValue, AllowNull = allowNull });
+            this.Parameters.Add(new SetupFilterParameter { Name = columnName, TableName = tableName, SchemaName = schemaName, DefaultValue = defaultValue, AllowNull = allowNull });
         }
 
 
@@ -99,12 +99,12 @@ namespace Dotmim.Sync
         /// For SQL Server, parameter will be added as @{parameterName}
         /// For MySql, parameter will be added as in_{parameterName}
         /// </summary>
-        public void AddParameter(string parameterName, string tableName, bool allowNull = false, string defaultValue = null)
+        public void AddParameter(string columnName, string tableName, bool allowNull = false, string defaultValue = null)
         {
-            if (this.Parameters.Any(p => string.Equals(p.Name, parameterName, SyncGlobalization.DataSourceStringComparison)))
-                throw new FilterParameterAlreadyExistsException(parameterName, this.TableName);
+            if (this.Parameters.Any(p => string.Equals(p.Name, columnName, SyncGlobalization.DataSourceStringComparison)))
+                throw new FilterParameterAlreadyExistsException(columnName, this.TableName);
 
-            this.Parameters.Add(new SetupFilterParameter { Name = parameterName, TableName = tableName, DefaultValue = defaultValue, AllowNull = allowNull });
+            this.Parameters.Add(new SetupFilterParameter { Name = columnName, TableName = tableName, DefaultValue = defaultValue, AllowNull = allowNull });
         }
 
 

--- a/Projects/Dotmim.Sync.Core/Setup/SetupFilter.cs
+++ b/Projects/Dotmim.Sync.Core/Setup/SetupFilter.cs
@@ -84,13 +84,13 @@ namespace Dotmim.Sync
         /// For SQL Server, parameter will be added as @{parameterName}
         /// For MySql, parameter will be added as in_{parameterName}
         /// </summary>
-        public void AddParameter(string columnName, string tableName, string schemaName, bool allowNull = false, string defaultValue = null)
+        public void AddParameter(string parameterName, string tableName, string schemaName, bool allowNull = false, string defaultValue = null)
         {
 
-            if (this.Parameters.Any(p => string.Equals(p.Name, columnName, SyncGlobalization.DataSourceStringComparison)))
-                throw new FilterParameterAlreadyExistsException(columnName, this.TableName);
+            if (this.Parameters.Any(p => string.Equals(p.Name, parameterName, SyncGlobalization.DataSourceStringComparison)))
+                throw new FilterParameterAlreadyExistsException(parameterName, this.TableName);
 
-            this.Parameters.Add(new SetupFilterParameter { Name = columnName, TableName = tableName, SchemaName = schemaName, DefaultValue = defaultValue, AllowNull = allowNull });
+            this.Parameters.Add(new SetupFilterParameter { Name = parameterName, TableName = tableName, SchemaName = schemaName, DefaultValue = defaultValue, AllowNull = allowNull });
         }
 
 
@@ -99,12 +99,12 @@ namespace Dotmim.Sync
         /// For SQL Server, parameter will be added as @{parameterName}
         /// For MySql, parameter will be added as in_{parameterName}
         /// </summary>
-        public void AddParameter(string columnName, string tableName, bool allowNull = false, string defaultValue = null)
+        public void AddParameter(string parameterName, string tableName, bool allowNull = false, string defaultValue = null)
         {
-            if (this.Parameters.Any(p => string.Equals(p.Name, columnName, SyncGlobalization.DataSourceStringComparison)))
-                throw new FilterParameterAlreadyExistsException(columnName, this.TableName);
+            if (this.Parameters.Any(p => string.Equals(p.Name, parameterName, SyncGlobalization.DataSourceStringComparison)))
+                throw new FilterParameterAlreadyExistsException(parameterName, this.TableName);
 
-            this.Parameters.Add(new SetupFilterParameter { Name = columnName, TableName = tableName, DefaultValue = defaultValue, AllowNull = allowNull });
+            this.Parameters.Add(new SetupFilterParameter { Name = parameterName, TableName = tableName, DefaultValue = defaultValue, AllowNull = allowNull });
         }
 
 


### PR DESCRIPTION
This tripped me up briefly when learning filters,
One AddParameter method of the SetupFilter class uses the arguement 'parameterName' which seems correct where as two others refer to it as 'columnName' which isn't accurate when your column and parameter have different names.