### PR TITLE
Set sync_scope_id parameter as Guid consistently in Buider classes.

### DIFF
--- a/Projects/Dotmim.Sync.MySql/Builders/MySqlScopeInfoBuilder.cs
+++ b/Projects/Dotmim.Sync.MySql/Builders/MySqlScopeInfoBuilder.cs
@@ -224,7 +224,7 @@ namespace Dotmim.Sync.MySql.Builders
 
             p = command.CreateParameter();
             p.ParameterName = "@sync_scope_id";
-            p.DbType = DbType.String;
+            p.DbType = DbType.Guid;
             p.Size = 36;
             command.Parameters.Add(p);
 
@@ -593,7 +593,7 @@ namespace Dotmim.Sync.MySql.Builders
 
             p = command.CreateParameter();
             p.ParameterName = "@sync_scope_id";
-            p.DbType = DbType.String;
+            p.DbType = DbType.Guid;
             p.Size = 36;
             command.Parameters.Add(p);
 
@@ -659,7 +659,7 @@ namespace Dotmim.Sync.MySql.Builders
 
             p = command.CreateParameter();
             p.ParameterName = "@sync_scope_id";
-            p.DbType = DbType.String;
+            p.DbType = DbType.Guid;
             p.Size = 36;
             command.Parameters.Add(p);
             

--- a/Projects/Dotmim.Sync.PostgreSql/Builders/NpgsqlScopeBuilder.cs
+++ b/Projects/Dotmim.Sync.PostgreSql/Builders/NpgsqlScopeBuilder.cs
@@ -117,7 +117,7 @@ namespace Dotmim.Sync.PostgreSql.Scope
 
             p = command.CreateParameter();
             p.ParameterName = "@sync_scope_id";
-            p.DbType = DbType.String;
+            p.DbType = DbType.Guid;
             p.Size = -1;
             command.Parameters.Add(p);
 
@@ -310,7 +310,7 @@ namespace Dotmim.Sync.PostgreSql.Scope
 
             var p0 = command.CreateParameter();
             p0.ParameterName = "@sync_scope_id";
-            p0.DbType = DbType.String;
+            p0.DbType = DbType.Guid;
             p0.Size = -1;
             command.Parameters.Add(p0);
 

--- a/Projects/Dotmim.Sync.SqlServer/Builders/SqlScopeBuilder.cs
+++ b/Projects/Dotmim.Sync.SqlServer/Builders/SqlScopeBuilder.cs
@@ -217,7 +217,7 @@ namespace Dotmim.Sync.SqlServer.Scope
 
             var p0 = command.CreateParameter();
             p0.ParameterName = "@sync_scope_id";
-            p0.DbType = DbType.String;
+            p0.DbType = DbType.Guid;
             p0.Size = -1;
             command.Parameters.Add(p0);
 
@@ -469,7 +469,7 @@ namespace Dotmim.Sync.SqlServer.Scope
 
             p = command.CreateParameter();
             p.ParameterName = "@sync_scope_id";
-            p.DbType = DbType.String;
+            p.DbType = DbType.Guid;
             p.Size = -1;
             command.Parameters.Add(p);
 
@@ -544,7 +544,7 @@ namespace Dotmim.Sync.SqlServer.Scope
 
             var p = command.CreateParameter();
             p.ParameterName = "@sync_scope_id";
-            p.DbType = DbType.String;
+            p.DbType = DbType.Guid;
             p.Size = -1;
             command.Parameters.Add(p);
 


### PR DESCRIPTION
Mixing `sync_scope_id` parameter types can cause issues with syncing. It seems in certain scenarios, GUID parameter converted as a string results in a malformed GUID in the form of `a0a0a0a0a-0001-0000-0000-000000000000` as seen in #962.

GUID values should always be always be converted as `DbType.Guid` consistently.