### PR TITLE
Prevent concurrency issues and clean up non-disposed objects

### DIFF
--- a/Projects/Dotmim.Sync.Core/Orchestrators/Commands/BaseOrchestrator.Commands.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/Commands/BaseOrchestrator.Commands.cs
@@ -252,10 +252,10 @@ namespace Dotmim.Sync
             foreach (var c in orderedNames)
                 changesTable.Columns.Add(c.Clone());
 
-            if (owner == null)
-                owner = new SyncSet();
-
-            owner.Tables.Add(changesTable);
+            if (owner != null)
+            {
+                owner.Tables.Add(changesTable);
+            }
 
             return changesTable;
         }


### PR DESCRIPTION
These changes fix about half of the errors that I detected using InferSharp. The other half involves refactoring the Newtonsoft-based JSON writing code, which seems best left to a separate PR.

These changes seem relatively safe, but please take a look.

Partially Fixes https://github.com/Mimetis/Dotmim.Sync/issues/1005