### PR TITLE
Add more locking in LocalJsonSerializer

### DIFF
--- a/Projects/Dotmim.Sync.Core/Serialization/LocalJsonSerializer.cs
+++ b/Projects/Dotmim.Sync.Core/Serialization/LocalJsonSerializer.cs
@@ -148,13 +148,25 @@ namespace Dotmim.Sync.Serialization
         /// </summary>
         public async Task WriteRowToFileAsync(SyncRow row, SyncTable schemaTable)
         {
-            writer.WriteStartArray();
-
             var innerRow = row.ToArray();
+
+            string str;
 
             if (this.writingRowAsync != null)
             {
-                var str = await this.writingRowAsync(schemaTable, innerRow);
+                str = await this.writingRowAsync(schemaTable, innerRow);
+            }
+            else
+            {
+                str = string.Empty; // This won't ever be used, but is need to compile.
+            }
+
+            lock (writerLock)
+            {
+                writer.WriteStartArray();
+
+                if (this.writingRowAsync != null)
+                {
                 writer.WriteValue(str);
             }
             else
@@ -167,6 +179,7 @@ namespace Dotmim.Sync.Serialization
             writer.WriteEndArray();
             writer.WriteWhitespace(Environment.NewLine);
             writer.Flush();
+            }
         }
 
         /// <summary>

--- a/Projects/Dotmim.Sync.Core/Serialization/LocalJsonSerializer.cs
+++ b/Projects/Dotmim.Sync.Core/Serialization/LocalJsonSerializer.cs
@@ -109,6 +109,8 @@ namespace Dotmim.Sync.Serialization
             this.sw = new StreamWriter(path, append);
             this.writer = new JsonTextWriter(sw) { CloseOutput = true, AutoCompleteOnClose = false };
 
+            lock (writerLock)
+            {
             this.writer.WriteStartObject();
             this.writer.WritePropertyName("t");
             this.writer.WriteStartArray();
@@ -141,6 +143,7 @@ namespace Dotmim.Sync.Serialization
             this.writer.WritePropertyName("r");
             this.writer.WriteStartArray();
             this.writer.WriteWhitespace(Environment.NewLine);
+            }
         }
         
         /// <summary>

--- a/Projects/Dotmim.Sync.Core/Serialization/LocalJsonSerializer.cs
+++ b/Projects/Dotmim.Sync.Core/Serialization/LocalJsonSerializer.cs
@@ -179,17 +179,24 @@ namespace Dotmim.Sync.Serialization
         /// </summary>
         public void OnReadingRow(Func<SyncTable, string, Task<object[]>> func) => this.readingRowAsync = func;
 
-
         /// <summary>
         /// Gets the file size
         /// </summary>
         /// <returns></returns>
         public Task<long> GetCurrentFileSizeAsync()
-            => this.sw != null && this.sw.BaseStream != null ?
-                Task.FromResult(this.sw.BaseStream.Position / 1024L) :
-                Task.FromResult(0L);
+        {
+            long position = 0L;
 
+            lock (writerLock)
+            {
+                if (this.sw != null && this.sw.BaseStream != null)
+                {
+                    position = this.sw.BaseStream.Position / 1024L;
+                }
+            }
 
+            return Task.FromResult(position);
+        }
 
         /// <summary>
         /// Get the table contained in a serialized file


### PR DESCRIPTION
Unless this is rewritten with System.Text.Json there is a lot of potential thread safety issues.

I have added some more locking to address this.

Fixes the remaining issues flagged here: https://github.com/Mimetis/Dotmim.Sync/issues/1005