### PR TITLE
Specify StringComparison directly

### DIFF
--- a/Projects/Dotmim.Sync.Core/Orchestrators/Upgrade/LocalOrchestrator.Upgrade.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/Upgrade/LocalOrchestrator.Upgrade.cs
@@ -466,11 +466,11 @@ namespace Dotmim.Sync
                                 throw new Exception("Your setup to migrate contains one or more filters. Please use a SyncParameters argument when calling ManualUpgradeWithFiltersParameterAsync() (or SynchronizeAsync()).");
 
                             foreach (var setupParameter in setupParameters)
-                                if (!parameters.Any(p => p.Name.ToLowerInvariant() == setupParameter.ToLowerInvariant()))
+                                if (!parameters.Any(p => string.Equals(p.Name, setupParameter, SyncGlobalization.DataSourceStringComparison)))
                                     throw new Exception("Your setup filters contains at least one parameter that is not available from SyncParameters argument.");
 
                             foreach (var parameter in parameters)
-                                if (!setupParameters.Any(n => n.ToLowerInvariant() == parameter.Name.ToLowerInvariant()))
+                                if (!setupParameters.Any(n => string.Equals(n, parameter.Name, SyncGlobalization.DataSourceStringComparison)))
                                     throw new Exception("Your SyncParameters argument contains a parameter that is not contained in your setup filters.");
                         }
                     }

--- a/Projects/Dotmim.Sync.Core/Serialization/SerializationFactoryCollection.cs
+++ b/Projects/Dotmim.Sync.Core/Serialization/SerializationFactoryCollection.cs
@@ -34,7 +34,7 @@ namespace Dotmim.Sync.Serialization
                 if (string.IsNullOrEmpty(key))
                     throw new ArgumentNullException("key");
 
-                return collection.FirstOrDefault(c => c.Key.ToLowerInvariant() == key.ToLowerInvariant());
+                return collection.FirstOrDefault(c => string.Equals(c.Key, key, SyncGlobalization.DataSourceStringComparison));
             }
         }
 

--- a/Projects/Dotmim.Sync.Core/SyncAgent.cs
+++ b/Projects/Dotmim.Sync.Core/SyncAgent.cs
@@ -237,7 +237,7 @@ namespace Dotmim.Sync
                 {
                     var remoteOrchestratorType = this.RemoteOrchestrator.GetType();
                     var providerType = remoteOrchestratorType.Name;
-                    if (providerType.ToLowerInvariant() == "webclientorchestrator" || providerType.ToLowerInvariant() == "webremotetorchestrator")
+                    if (string.Equals(providerType, "webclientorchestrator", SyncGlobalization.DataSourceStringComparison) || string.Equals(providerType, "webremotetorchestrator", SyncGlobalization.DataSourceStringComparison))
                         throw new Exception("Do not set Tables (or SyncSetup) from your client. Please use SyncAgent, without any Tables or SyncSetup. The tables will come from the server side");
                 }
 

--- a/Projects/Dotmim.Sync.MySql/Builders/MySqlBuilderTable.cs
+++ b/Projects/Dotmim.Sync.MySql/Builders/MySqlBuilderTable.cs
@@ -339,8 +339,11 @@ namespace Dotmim.Sync.MySql.Builders
                     DefaultValue = c["COLUMN_DEFAULT"].ToString(),
                     ExtraProperty1 = c["column_type"] != DBNull.Value ? c["column_type"].ToString() : null,
                     IsUnsigned = c["column_type"] != DBNull.Value && ((string)c["column_type"]).Contains("unsigned"),
+#if NETSTANDARD2_0
                     IsUnique = c["column_key"] != DBNull.Value && ((string)c["column_key"]).ToLowerInvariant().Contains("uni")
-
+#else
+                    IsUnique = c["column_key"] != DBNull.Value && ((string)c["column_key"]).Contains("uni", SyncGlobalization.DataSourceStringComparison)
+#endif
                 };
 
                 var extra = c["extra"] != DBNull.Value ? ((string)c["extra"]).ToLowerInvariant() : null;

--- a/Projects/Dotmim.Sync.MySql/Builders/MySqlDbMetadata.cs
+++ b/Projects/Dotmim.Sync.MySql/Builders/MySqlDbMetadata.cs
@@ -163,13 +163,21 @@ namespace Dotmim.Sync.MySql.Builders
         public override int GetMaxLength(SyncColumn columnDefinition)
         {
             // blob
-            if (columnDefinition.OriginalTypeName.ToLowerInvariant() == "longblob" || columnDefinition.OriginalTypeName.ToLowerInvariant() == "mediumblob" || columnDefinition.OriginalTypeName.ToLowerInvariant() == "tinyblob")
+            if (string.Equals(columnDefinition.OriginalTypeName, "longblob", SyncGlobalization.DataSourceStringComparison)
+                || string.Equals(columnDefinition.OriginalTypeName, "mediumblob", SyncGlobalization.DataSourceStringComparison)
+                || string.Equals(columnDefinition.OriginalTypeName, "tinyblob", SyncGlobalization.DataSourceStringComparison))
+            {
                 return 0;
+            }
 
             // text
-            if (columnDefinition.OriginalTypeName.ToLowerInvariant() == "longtext" || columnDefinition.OriginalTypeName.ToLowerInvariant() == "mediumtext"
-                || columnDefinition.OriginalTypeName.ToLowerInvariant() == "tinytext" || columnDefinition.OriginalTypeName.ToLowerInvariant() == "json")
+            if (string.Equals(columnDefinition.OriginalTypeName, "longtext", SyncGlobalization.DataSourceStringComparison)
+                || string.Equals(columnDefinition.OriginalTypeName, "mediumtext", SyncGlobalization.DataSourceStringComparison)
+                || string.Equals(columnDefinition.OriginalTypeName, "tinytext", SyncGlobalization.DataSourceStringComparison)
+                || string.Equals(columnDefinition.OriginalTypeName, "json", SyncGlobalization.DataSourceStringComparison))
+            {
                 return 0;
+            }
 
             var iMaxLength = columnDefinition.MaxLength > 8000 ? 8000 : Convert.ToInt32(columnDefinition.MaxLength);
             return iMaxLength;

--- a/Projects/Dotmim.Sync.MySql/MySqlExtensionsMethods.cs
+++ b/Projects/Dotmim.Sync.MySql/MySqlExtensionsMethods.cs
@@ -291,9 +291,13 @@ namespace Dotmim.Sync.MySql
                 row["NUMERIC_PRECISION"] = 10;
                 row["NUMERIC_SCALE"] = 0;
 
-                if (type.ToLowerInvariant() == "numeric" || type.ToLowerInvariant() == "decimal" ||
-                    type.ToLowerInvariant() == "dec" || type.ToLowerInvariant() == "real")
+                if (string.Equals(type, "numeric", SyncGlobalization.DataSourceStringComparison)
+                    || string.Equals(type, "decimal", SyncGlobalization.DataSourceStringComparison)
+                    || string.Equals(type, "dec", SyncGlobalization.DataSourceStringComparison)
+                    || string.Equals(type, "real", SyncGlobalization.DataSourceStringComparison))
+                {
                     format = "({0})";
+                }
 
                 return String.Format(format, row["NUMERIC_PRECISION"],
                     row["NUMERIC_SCALE"]);

--- a/Projects/Dotmim.Sync.PostgreSql/Builders/NpgsqlDbMetadata.cs
+++ b/Projects/Dotmim.Sync.PostgreSql/Builders/NpgsqlDbMetadata.cs
@@ -397,7 +397,7 @@ namespace Dotmim.Sync.PostgreSql.Builders
             }
             return false;
         }
-        public override bool IsReadonly(SyncColumn columnDefinition) => columnDefinition.OriginalTypeName.ToLowerInvariant() == "timestamp" || columnDefinition.IsCompute;
+        public override bool IsReadonly(SyncColumn columnDefinition) => string.Equals(columnDefinition.OriginalTypeName, "timestamp", SyncGlobalization.DataSourceStringComparison) || columnDefinition.IsCompute;
         public override bool IsSupportingScale(SyncColumn columnDefinition)
         {
             switch (columnDefinition.OriginalTypeName.ToLowerInvariant())

--- a/Projects/Dotmim.Sync.SqlServer/Builders/SqlDbMetadata.cs
+++ b/Projects/Dotmim.Sync.SqlServer/Builders/SqlDbMetadata.cs
@@ -224,7 +224,7 @@ namespace Dotmim.Sync.SqlServer.Manager
             _ => false,
         };
         public override bool IsReadonly(SyncColumn columnDefinition)
-            => columnDefinition.OriginalTypeName.ToLowerInvariant() == "timestamp" || columnDefinition.IsCompute;
+            => string.Equals(columnDefinition.OriginalTypeName, "timestamp", SyncGlobalization.DataSourceStringComparison) || columnDefinition.IsCompute;
 
         //------------------------------------------------------------------------
 

--- a/Projects/Dotmim.Sync.Sqlite/SqliteSyncProvider.cs
+++ b/Projects/Dotmim.Sync.Sqlite/SqliteSyncProvider.cs
@@ -121,7 +121,7 @@ namespace Dotmim.Sync.Sqlite
         }
         public SqliteSyncProvider(string filePath) : this()
         {
-            if (filePath.ToLowerInvariant().StartsWith("data source"))
+            if (filePath.StartsWith("data source", SyncGlobalization.DataSourceStringComparison))
             {
                 this.builder = new SqliteConnectionStringBuilder(filePath);
             }

--- a/Tests/Dotmim.Sync.Tests/Setup.cs
+++ b/Tests/Dotmim.Sync.Tests/Setup.cs
@@ -38,7 +38,7 @@ namespace Dotmim.Sync.Tests
             {
                 // check if we are running on appveyor or not
                 string isOnAzureDev = Environment.GetEnvironmentVariable("AZUREDEV");
-                return !string.IsNullOrEmpty(isOnAzureDev) && isOnAzureDev.ToLowerInvariant() == "true";
+                return !string.IsNullOrEmpty(isOnAzureDev) && string.Equals(isOnAzureDev, "true", SyncGlobalization.DataSourceStringComparison);
             }
         }
 


### PR DESCRIPTION
This should be slightly faster and also more explicit. It is the recommended pattern in StyleCop. I used an automated refactoring which ensures that the StringComparison type was unchanged.

see: [CA1307](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1307), [CA1310](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1310)