### PR TITLE
Make some methods and classes static

### DIFF
--- a/Projects/Dotmim.Sync.Core/Logger/SyncLogger.cs
+++ b/Projects/Dotmim.Sync.Core/Logger/SyncLogger.cs
@@ -106,7 +106,7 @@ namespace Dotmim.Sync
         /// <summary>
         /// Write a messages without returning to new line
         /// </summary>
-        internal void Write(OutputWriter outputWriter, string message, ConsoleColor? background = default, ConsoleColor? foreground = default)
+        internal static void Write(OutputWriter outputWriter, string message, ConsoleColor? background = default, ConsoleColor? foreground = default)
         {
             outputWriter.SetColor(background, foreground);
             outputWriter.Write(message);
@@ -116,7 +116,7 @@ namespace Dotmim.Sync
         /// <summary>
         /// Write a messages and returns to new line
         /// </summary>
-        internal void WriteLine(OutputWriter outputWriter, string message, ConsoleColor? background = default, ConsoleColor? foreground = default)
+        internal static void WriteLine(OutputWriter outputWriter, string message, ConsoleColor? background = default, ConsoleColor? foreground = default)
         {
             outputWriter.SetColor(background, foreground);
             outputWriter.WriteLine(message);
@@ -222,7 +222,7 @@ namespace Dotmim.Sync
                        && (type.Attributes & TypeAttributes.NotPublic) == TypeAttributes.NotPublic;
         }
 
-        private ConsoleColors GetLogLevelConsoleColors(LogLevel logLevel)
+        private static ConsoleColors GetLogLevelConsoleColors(LogLevel logLevel)
         {
             // We must explicitly set the background color if we are setting the foreground color,
             // since just setting one can look bad on the users console.

--- a/Projects/Dotmim.Sync.Core/Orchestrators/BaseOrchestrator.BatchInfo.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/BaseOrchestrator.BatchInfo.cs
@@ -55,7 +55,7 @@ namespace Dotmim.Sync
 
                 foreach (var file in directory.GetFiles())
                 {
-                    var (schemaTable, rowsCount, state) = localSerializer.GetSchemaTableFromFile(file.FullName);
+                    var (schemaTable, rowsCount, state) = LocalJsonSerializer.GetSchemaTableFromFile(file.FullName);
                     batchInfo.BatchPartsInfo.Add(new BatchPartInfo(file.Name, schemaTable.TableName, schemaTable.SchemaName, state, rowsCount));
                 }
                 batchInfos.Add(batchInfo);
@@ -116,7 +116,7 @@ namespace Dotmim.Sync
                         if (!File.Exists(fullPath))
                             continue;
 
-                        var (syncTable, _, _) = localSerializer.GetSchemaTableFromFile(fullPath);
+                        var (syncTable, _, _) = LocalJsonSerializer.GetSchemaTableFromFile(fullPath);
 
                         // on first iteration, creating the return table
                         currentTable ??= syncTable.Clone();
@@ -198,7 +198,7 @@ namespace Dotmim.Sync
 
                 // Get table from file
                 if (syncTable == null)
-                    (syncTable, _, _) = localSerializer.GetSchemaTableFromFile(fullPath);
+                    (syncTable, _, _) = LocalJsonSerializer.GetSchemaTableFromFile(fullPath);
 
                 foreach (var syncRow in localSerializer.GetRowsFromFile(fullPath, syncTable))
                     if (!syncRowState.HasValue || syncRowState == default || (syncRowState.HasValue && syncRowState.Value.HasFlag(syncRow.RowState)))
@@ -245,7 +245,7 @@ namespace Dotmim.Sync
             var localSerializer = new LocalJsonSerializer(this, context);
 
             // Get table from file
-            var (syncTable, _, _) = localSerializer.GetSchemaTableFromFile(fullPath);
+            var (syncTable, _, _) = LocalJsonSerializer.GetSchemaTableFromFile(fullPath);
 
             foreach (var syncRow in localSerializer.GetRowsFromFile(fullPath, syncTable))
                 if (!syncRowState.HasValue || syncRowState == default || (syncRowState.HasValue && syncRowState.Value.HasFlag(syncRow.RowState)))

--- a/Projects/Dotmim.Sync.Core/Orchestrators/Provision/RemoteOrchestrator.Provision.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/Provision/RemoteOrchestrator.Provision.cs
@@ -257,7 +257,7 @@ namespace Dotmim.Sync
                 await using var runner = await this.GetConnectionAsync(context, SyncMode.WithTransaction, SyncStage.Deprovisioning, connection, transaction, cancellationToken, progress).ConfigureAwait(false);
 
                 // Creating a fake scope info
-                var serverScopeInfo = this.InternalCreateScopeInfo(scopeName);
+                var serverScopeInfo = InternalCreateScopeInfo(scopeName);
                 serverScopeInfo.Setup = setup;
                 serverScopeInfo.Schema = new SyncSet(setup);
 

--- a/Projects/Dotmim.Sync.Core/Orchestrators/Scopes/LocalOrchestrator.ScopeInfos.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/Scopes/LocalOrchestrator.ScopeInfos.cs
@@ -88,7 +88,7 @@ namespace Dotmim.Sync
 
                 if (!cScopeInfoExists)
                 {
-                    cScopeInfo = this.InternalCreateScopeInfo(context.ScopeName);
+                    cScopeInfo = InternalCreateScopeInfo(context.ScopeName);
                     (context, cScopeInfo) = await this.InternalSaveScopeInfoAsync(cScopeInfo, context, runner.Connection, runner.Transaction, runner.CancellationToken, runner.Progress).ConfigureAwait(false);
                 }
                 else

--- a/Projects/Dotmim.Sync.Core/Serialization/LocalJsonSerializer.cs
+++ b/Projects/Dotmim.Sync.Core/Serialization/LocalJsonSerializer.cs
@@ -234,7 +234,7 @@ namespace Dotmim.Sync.Serialization
         /// <summary>
         /// Get the table contained in a serialized file
         /// </summary>
-        public (SyncTable schemaTable, int rowsCount, SyncRowState state) GetSchemaTableFromFile(string path)
+        public static (SyncTable schemaTable, int rowsCount, SyncRowState state) GetSchemaTableFromFile(string path)
         {
             if (!File.Exists(path))
                 return default;
@@ -457,7 +457,7 @@ namespace Dotmim.Sync.Serialization
 
         }
 
-        private SyncTable GetSchemaTableFromReader(JsonTextReader reader, JsonSerializer serializer, string tableName, string schemaName)
+        private static SyncTable GetSchemaTableFromReader(JsonTextReader reader, JsonSerializer serializer, string tableName, string schemaName)
         {
             SyncTable schemaTable;
 

--- a/Projects/Dotmim.Sync.Core/SyncTypeConverter.cs
+++ b/Projects/Dotmim.Sync.Core/SyncTypeConverter.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace Dotmim.Sync
 {
-    public class SyncTypeConverter
+    public static class SyncTypeConverter
     {
         public static T TryConvertTo<T>(dynamic value, CultureInfo provider = default)
         {

--- a/Projects/Dotmim.Sync.MySql/MySqlTokenizer.cs
+++ b/Projects/Dotmim.Sync.MySql/MySqlTokenizer.cs
@@ -293,17 +293,17 @@ namespace Dotmim.Sync.MySql
             stopIndex = pos;
         }
 
-        private bool IsQuoteChar(char c)
+        private static bool IsQuoteChar(char c)
         {
             return c == '`' || c == '\'' || c == '\"';
         }
 
-        private bool IsParameterMarker(char c)
+        private static bool IsParameterMarker(char c)
         {
             return c == '@' || c == '?';
         }
 
-        private bool IsSpecialCharacter(char c)
+        private static bool IsSpecialCharacter(char c)
         {
             if (Char.IsLetterOrDigit(c) ||
                 c == '$' || c == '_' || c == '.') return false;

--- a/Samples/Dotmim.Sync.SampleConsole/DBHelper.cs
+++ b/Samples/Dotmim.Sync.SampleConsole/DBHelper.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Dotmim.Sync.SampleConsole
 {
-    public class DBHelper
+    public static class DBHelper
     {
         private static IConfiguration configuration;
 


### PR DESCRIPTION
May help with performance and also help to enforce correctness. Accomplished with automatic refactoring via [Roslyn Analyzers](https://github.com/dotnet/roslyn-analyzers).

see [CA1822](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1822)