### PR TITLE
return Task instead of null

### DIFF
--- a/Projects/Dotmim.Sync.SqlServer/Builders/SqlBuilderTable.cs
+++ b/Projects/Dotmim.Sync.SqlServer/Builders/SqlBuilderTable.cs
@@ -293,7 +293,7 @@ namespace Dotmim.Sync.SqlServer.Builders
             var schema = SqlManagementUtils.GetUnquotedSqlSchemaName(tableName);
 
             if (schema == "dbo")
-                return null;
+                return Task.FromResult<DbCommand>(null);
 
             var command = connection.CreateCommand();
 


### PR DESCRIPTION
Awaiting a task-returning method that returns null can result in a NullReferenceException

https://www.zachsnoek.com/blog/returning-null-from-task-returning-methods-in-c-sharp