### PR TITLE
use TryGetAdd to avoid double lookups

### DIFF
--- a/Projects/Dotmim.Sync.Core/Set/SyncColumn.cs
+++ b/Projects/Dotmim.Sync.Core/Set/SyncColumn.cs
@@ -367,8 +367,8 @@ namespace Dotmim.Sync
         {
             var type = this.GetDataType();
 
-            if (StorageClassType.ContainsKey(type))
-                return StorageClassType[type];
+            if (StorageClassType.TryGetValue(type, out var storageClassType))
+                return storageClassType;
 
             return type.GetTypeInfo().IsValueType;
         }

--- a/Projects/Dotmim.Sync.Core/Set/SyncColumns.cs
+++ b/Projects/Dotmim.Sync.Core/Set/SyncColumns.cs
@@ -59,8 +59,8 @@ namespace Dotmim.Sync
             get
             {
                 //InnerCollection.FirstOrDefault(c => string.Equals(c.ColumnName, columnName, SyncGlobalization.DataSourceStringComparison));
-                if (indexes.ContainsKey(columnName.ToLowerInvariant()))
-                    return InnerCollection[indexes[columnName.ToLowerInvariant()]];
+                if (indexes.TryGetValue(columnName.ToLowerInvariant(), out var index))
+                    return InnerCollection[index];
 
                 return null;
             }

--- a/Projects/Dotmim.Sync.PostgreSql/Builders/NpgsqlBuilderTable.cs
+++ b/Projects/Dotmim.Sync.PostgreSql/Builders/NpgsqlBuilderTable.cs
@@ -417,10 +417,10 @@ namespace Dotmim.Sync.PostgreSql.Builders
         /// </summary>
         public string NormalizeRelationName(string relation)
         {
-            if (createdRelationNames.ContainsKey(relation))
-                return createdRelationNames[relation];
+            if (createdRelationNames.TryGetValue(relation, out var name))
+                return name;
 
-            var name = relation;
+            name = relation;
 
             if (relation.Length > 128)
                 name = $"{relation.Substring(0, 110)}_{GetRandomString()}";

--- a/Projects/Dotmim.Sync.SqlServer/Builders/SqlBuilderTable.cs
+++ b/Projects/Dotmim.Sync.SqlServer/Builders/SqlBuilderTable.cs
@@ -47,10 +47,10 @@ namespace Dotmim.Sync.SqlServer.Builders
         /// </summary>
         public string NormalizeRelationName(string relation)
         {
-            if (createdRelationNames.ContainsKey(relation))
-                return createdRelationNames[relation];
+            if (createdRelationNames.TryGetValue(relation, out var name))
+                return name;
 
-            var name = relation;
+            name = relation;
 
             if (relation.Length > 128)
                 name = $"{relation.Substring(0, 110)}_{GetRandomString()}";

--- a/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
@@ -251,9 +251,9 @@ namespace Dotmim.Sync.SqlServer.Builders
 
                 textParser = $"{source}-{textParser}";
 
-                if (derivingParameters.ContainsKey(textParser))
+                if (derivingParameters.TryGetValue(textParser, out var parameters))
                 {
-                    foreach (var p in derivingParameters[textParser])
+                    foreach (var p in parameters)
                         command.Parameters.Add(p.Clone());
                 }
                 else


### PR DESCRIPTION
This is a small performance optimization

see: [CA1854](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1854)