### PR TITLE
Use pattern matching without casting

### DIFF
--- a/Projects/Dotmim.Sync.Core/EnumerableExtensions.cs
+++ b/Projects/Dotmim.Sync.Core/EnumerableExtensions.cs
@@ -25,9 +25,9 @@ namespace Dotmim.Sync
             , int defaultCapacity = 10)
         {
 
-            if (source is ICollection<T>)
+            if (source is ICollection<T> collections)
             {
-                defaultCapacity = ((ICollection<T>)source).Count + 1;
+                defaultCapacity = collections.Count + 1;
             }
             var sorted = new List<T>(defaultCapacity);
             var visited = new HashSet<T>();

--- a/Projects/Dotmim.Sync.Core/Set/SyncNamedItem.cs
+++ b/Projects/Dotmim.Sync.Core/Set/SyncNamedItem.cs
@@ -26,15 +26,13 @@ namespace Dotmim.Sync
             if (otherInstance == null)
                 return false;
 
-            var namedOhterInstance = otherInstance as SyncNamedItem<T>;
-
-            if (namedOhterInstance == null)
+            if (otherInstance is not SyncNamedItem<T> namedOtherInstance)
                 return false;
 
             var sc = SyncGlobalization.DataSourceStringComparison;
 
             var props1 = this.GetAllNamesProperties().GetEnumerator();
-            var props2 = namedOhterInstance.GetAllNamesProperties().GetEnumerator();
+            var props2 = namedOtherInstance.GetAllNamesProperties().GetEnumerator();
 
 
             while (props1.MoveNext())

--- a/Projects/Dotmim.Sync.Core/SyncAgent.cs
+++ b/Projects/Dotmim.Sync.Core/SyncAgent.cs
@@ -475,8 +475,8 @@ namespace Dotmim.Sync
                 if (this.Options.Logger != null)
                     this.Options.Logger.LogError(SyncEventsId.Exception, exception, exception.Message);
 
-                if (exception is SyncException)
-                    syncException = (SyncException)exception;
+                if (exception is SyncException ex)
+                    syncException = ex;
                 else
                     syncException = new SyncException(exception);
 

--- a/Projects/Dotmim.Sync.Core/SyncTypeConverter.cs
+++ b/Projects/Dotmim.Sync.Core/SyncTypeConverter.cs
@@ -39,8 +39,8 @@ namespace Dotmim.Sync
                 return Convert.ToUInt64(value);
             else if (typeOfT == typeof(DateTime))
             {
-                if (value is DateTimeOffset)
-                    return (T)Convert.ChangeType(((DateTimeOffset)value).DateTime, typeOfT, provider);
+                if (value is DateTimeOffset dateTimeOffset)
+                    return (T)Convert.ChangeType(dateTimeOffset.DateTime, typeOfT, provider);
 
                 string valueStr = value.ToString(); // IOS bug ????
                 if (DateTime.TryParse(valueStr, provider, DateTimeStyles.None, out DateTime dateTime))
@@ -52,10 +52,10 @@ namespace Dotmim.Sync
             }
             else if (typeOfT == typeof(DateTimeOffset))
             {
-                if (value is DateTime)
-                    return (T)Convert.ChangeType(new DateTimeOffset((DateTime)value), typeOfT, provider);
-                else if (DateTimeOffset.TryParse(value.ToString(), provider, DateTimeStyles.None, out DateTimeOffset dateTime))
-                    return (T)Convert.ChangeType(dateTime, typeOfT, provider);
+                if (value is DateTime dateTime)
+                    return (T)Convert.ChangeType(new DateTimeOffset(dateTime), typeOfT, provider);
+                else if (DateTimeOffset.TryParse(value.ToString(), provider, DateTimeStyles.None, out DateTimeOffset dateTimeOffset))
+                    return (T)Convert.ChangeType(dateTimeOffset, typeOfT, provider);
                 else if (typeOfU == typeof(long))
                     return (T)Convert.ChangeType(new DateTimeOffset(new DateTime(value)), typeOfT, provider);
                 else

--- a/Projects/Dotmim.Sync.MariaDB/MariaDBSyncProvider.cs
+++ b/Projects/Dotmim.Sync.MariaDB/MariaDBSyncProvider.cs
@@ -123,9 +123,7 @@ namespace Dotmim.Sync.MariaDB
                 syncException.InitialCatalog = builder.Database;
             }
 
-            var mySqlException = syncException.InnerException as MySqlException;
-
-            if (mySqlException == null)
+            if (syncException.InnerException is not MySqlException mySqlException)
                 return;
 
             syncException.Number = mySqlException.Number;
@@ -138,8 +136,8 @@ namespace Dotmim.Sync.MariaDB
             Exception ex = exception;
             while (ex != null)
             {
-                if (ex is MySqlException)
-                    return MySqlTransientExceptionDetector.ShouldRetryOn((MySqlException)ex);
+                if (ex is MySqlException mySqlException)
+                    return MySqlTransientExceptionDetector.ShouldRetryOn(mySqlException);
                 else
                     ex = ex.InnerException;
             }

--- a/Projects/Dotmim.Sync.MySql/MySqlSyncProvider.cs
+++ b/Projects/Dotmim.Sync.MySql/MySqlSyncProvider.cs
@@ -92,8 +92,8 @@ namespace Dotmim.Sync.MySql
             Exception ex = exception;
             while (ex != null)
             {
-                if (ex is MySqlException)
-                    return MySqlTransientExceptionDetector.ShouldRetryOn((MySqlException)ex);
+                if (ex is MySqlException mySqlException)
+                    return MySqlTransientExceptionDetector.ShouldRetryOn(mySqlException);
                 else
                     ex = ex.InnerException;
             }
@@ -132,9 +132,7 @@ namespace Dotmim.Sync.MySql
                 syncException.InitialCatalog = builder.Database;
             }
 
-            var mySqlException = syncException.InnerException as MySqlException;
-
-            if (mySqlException == null)
+            if (syncException.InnerException is not MySqlException mySqlException)
                 return;
 
             syncException.Number = mySqlException.Number;

--- a/Projects/Dotmim.Sync.PostgreSql/NpgsqlSyncProvider.cs
+++ b/Projects/Dotmim.Sync.PostgreSql/NpgsqlSyncProvider.cs
@@ -83,8 +83,8 @@ namespace Dotmim.Sync.PostgreSql
             Exception ex = exception;
             while (ex != null)
             {
-                if (ex is NpgsqlException)
-                    return ((NpgsqlException)ex).IsTransient;
+                if (ex is NpgsqlException npgsqlException)
+                    return npgsqlException.IsTransient;
                 else
                     ex = ex.InnerException;
             }

--- a/Projects/Dotmim.Sync.SqlServer/SqlSyncProvider.cs
+++ b/Projects/Dotmim.Sync.SqlServer/SqlSyncProvider.cs
@@ -124,9 +124,7 @@ namespace Dotmim.Sync.SqlServer
             }
 
             // Can add more info from SqlException
-            var sqlException = syncException.InnerException as SqlException;
-
-            if (sqlException == null)
+            if (syncException.InnerException is not SqlException sqlException)
                 return;
 
             syncException.Number = sqlException.Number;

--- a/Projects/Dotmim.Sync.Sqlite/SqliteSyncProvider.cs
+++ b/Projects/Dotmim.Sync.Sqlite/SqliteSyncProvider.cs
@@ -112,8 +112,8 @@ namespace Dotmim.Sync.Sqlite
             Exception ex = exception;
             while (ex != null)
             {
-                if (ex is SqliteException)
-                    return SqliteTransientExceptionDetector.ShouldRetryOn((SqliteException)ex);
+                if (ex is SqliteException sqliteException)
+                    return SqliteTransientExceptionDetector.ShouldRetryOn(sqliteException);
                 else
                     ex = ex.InnerException;
             }
@@ -163,13 +163,10 @@ namespace Dotmim.Sync.Sqlite
 
         public override void EnsureSyncException(SyncException syncException)
         {
-
             if (builder != null)
                 syncException.DataSource = builder.DataSource;
 
-            var sqliteException = syncException.InnerException as SqliteException;
-
-            if (sqliteException == null)
+            if (syncException.InnerException is not SqliteException sqliteException)
                 return;
 
             syncException.Number = sqliteException.SqliteErrorCode;

--- a/Projects/Dotmim.Sync.Web.Server/WebServerAgent.cs
+++ b/Projects/Dotmim.Sync.Web.Server/WebServerAgent.cs
@@ -286,8 +286,8 @@ namespace Dotmim.Sync.Web.Server
                 httpContext.Session.Set(sessionId, sessionCache);
                 await httpContext.Session.CommitAsync(cancellationToken);
 
-                if (messageResponse is HttpMessageSendChangesResponse)
-                    await this.RemoteOrchestrator.InterceptAsync(new HttpSendingServerChangesArgs((HttpMessageSendChangesResponse)messageResponse, httpContext.Request.Host.Host, sessionCache, false), progress, cancellationToken).ConfigureAwait(false);
+                if (messageResponse is HttpMessageSendChangesResponse httpMessageSendChangesResponse)
+                    await this.RemoteOrchestrator.InterceptAsync(new HttpSendingServerChangesArgs(httpMessageSendChangesResponse, httpContext.Request.Host.Host, sessionCache, false), progress, cancellationToken).ConfigureAwait(false);
 
                 await this.RemoteOrchestrator.InterceptAsync(new HttpSendingResponseArgs(httpContext, messageResponse.SyncContext, sessionCache, messageResponse, responseSerializerType, step), progress, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
This will reduce casting, because pattern matching already does casting internally. Also makes the code more readable.

I used automatic refactoring via Roslynator to accomplish this.