### PR TITLE
Fix for #1025 SqlServer.ChangeTracking MissingPrimaryKeyException: Table MSchange_tracking_history does not have any primary key.

### DIFF
--- a/Projects/Dotmim.Sync.SqlServer/SqlManagementUtils.cs
+++ b/Projects/Dotmim.Sync.SqlServer/SqlManagementUtils.cs
@@ -24,7 +24,7 @@ namespace Dotmim.Sync.SqlServer
             var command = $"Select tbl.name as TableName, " +
                           $"sch.name as SchemaName " +
                           $"  from sys.tables as tbl  " +
-                          $"  Inner join sys.schemas as sch on tbl.schema_id = sch.schema_id;";
+                          $"  Inner join sys.schemas as sch on tbl.schema_id = sch.schema_id where tbl.is_ms_shipped = 0;";
 
             var syncSetup = new SyncSetup();
 


### PR DESCRIPTION
When using sql change tracking the system table MSChange_tracking_history is created. It should not be included in the list generated by GetAllTablesAsync. It can be excluded by requesting only records from sys.tables where is_ms_shipped=0.