### PR TITLE
Avoid double lookups with dictionaries

### DIFF
--- a/Projects/Dotmim.Sync.Core/Orchestrators/Upgrade/LocalOrchestrator.Upgrade.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/Upgrade/LocalOrchestrator.Upgrade.cs
@@ -148,9 +148,9 @@ namespace Dotmim.Sync
                 JObject setup = JToken.Parse(setupJson) as JObject;
 
                 // Raise an error if we have more than one scope with filters
-                if (setup != null && setup.ContainsKey("fils"))
+                if (setup != null && setup.TryGetValue("fils", out var fils))
                 {
-                    var filters = setup["fils"].ToObject<List<SetupFilter>>();
+                    var filters = fils.ToObject<List<SetupFilter>>();
                     hasFilters = filters != null && filters.Count > 0;
                     if (hasFilters)
                     {

--- a/Projects/Dotmim.Sync.MySql/Builders/MySqlBuilderTable.cs
+++ b/Projects/Dotmim.Sync.MySql/Builders/MySqlBuilderTable.cs
@@ -39,10 +39,10 @@ namespace Dotmim.Sync.MySql.Builders
         /// </summary>
         public static string NormalizeRelationName(string relation)
         {
-            if (createdRelationNames.ContainsKey(relation))
-                return createdRelationNames[relation];
+            if (createdRelationNames.TryGetValue(relation, out var name))
+                return name;
 
-            var name = relation;
+            name = relation;
 
             if (relation.Length > 65)
                 name = $"{relation.Substring(0, 50)}_{GetRandomString()}";
@@ -51,6 +51,7 @@ namespace Dotmim.Sync.MySql.Builders
 
             return name;
         }
+
         public MySqlBuilderTable(SyncTable tableDescription, ParserName tableName, ParserName trackingName, SyncSetup setup)
         {
             this.tableDescription = tableDescription;

--- a/Projects/Dotmim.Sync.MySql/Builders/MySqlObjectNames.cs
+++ b/Projects/Dotmim.Sync.MySql/Builders/MySqlObjectNames.cs
@@ -67,12 +67,11 @@ namespace Dotmim.Sync.MySql.Builders
 
             commandNames.Add(objectType, name);
         }
+
         public string GetCommandName(DbCommandType objectType, SyncFilter filter = null)
         {
-            if (!commandNames.ContainsKey(objectType))
+            if (!commandNames.TryGetValue(objectType, out var commandName))
                 throw new NotSupportedException($"MySql provider does not support the command type {objectType.ToString()}");
-
-            var commandName = commandNames[objectType];
 
             // concat filter name
             if (filter != null)
@@ -88,12 +87,11 @@ namespace Dotmim.Sync.MySql.Builders
 
             storedProceduresNames.Add(objectType, name);
         }
+
         public string GetStoredProcedureCommandName(DbStoredProcedureType storedProcedureType, SyncFilter filter = null)
         {
-            if (!storedProceduresNames.ContainsKey(storedProcedureType))
+            if (!storedProceduresNames.TryGetValue(storedProcedureType, out var commandName))
                 throw new Exception("Yous should provide a value for all DbCommandName");
-
-            var commandName = storedProceduresNames[storedProcedureType];
 
             // concat filter name
             if (filter != null && (storedProcedureType == DbStoredProcedureType.SelectChangesWithFilters || storedProcedureType == DbStoredProcedureType.SelectInitializedChangesWithFilters))
@@ -109,12 +107,11 @@ namespace Dotmim.Sync.MySql.Builders
 
             triggersNames.Add(objectType, name);
         }
+
         public string GetTriggerCommandName(DbTriggerType objectType, SyncFilter filter = null)
         {
-            if (!triggersNames.ContainsKey(objectType))
+            if (!triggersNames.TryGetValue(objectType, out var commandName))
                 throw new Exception("Yous should provide a value for all DbCommandName");
-
-            var commandName = triggersNames[objectType];
 
             // concat filter name
             if (filter != null)
@@ -122,7 +119,6 @@ namespace Dotmim.Sync.MySql.Builders
 
             return commandName;
         }
-
 
         public MySqlObjectNames(SyncTable tableDescription, ParserName tableName, ParserName trackingName, SyncSetup setup, string scopeName)
         {

--- a/Projects/Dotmim.Sync.SqlServer/Builders/SqlObjectNames.cs
+++ b/Projects/Dotmim.Sync.SqlServer/Builders/SqlObjectNames.cs
@@ -58,12 +58,11 @@ namespace Dotmim.Sync.SqlServer.Builders
 
             storedProceduresNames.Add(objectType, name);
         }
+
         public string GetStoredProcedureCommandName(DbStoredProcedureType storedProcedureType, SyncFilter filter = null)
         {
-            if (!storedProceduresNames.ContainsKey(storedProcedureType))
+            if (!storedProceduresNames.TryGetValue(storedProcedureType, out var commandName))
                 throw new Exception("Yous should provide a value for all DbCommandName");
-
-            var commandName = storedProceduresNames[storedProcedureType];
 
             // concat filter name
             if (filter != null && (storedProcedureType == DbStoredProcedureType.SelectChangesWithFilters || storedProcedureType == DbStoredProcedureType.SelectInitializedChangesWithFilters))
@@ -79,12 +78,11 @@ namespace Dotmim.Sync.SqlServer.Builders
 
             triggersNames.Add(objectType, name);
         }
+
         public string GetTriggerCommandName(DbTriggerType objectType, SyncFilter filter = null)
         {
-            if (!triggersNames.ContainsKey(objectType))
+            if (!triggersNames.TryGetValue(objectType, out var commandName))
                 throw new Exception("Yous should provide a value for all DbCommandName");
-
-            var commandName = triggersNames[objectType];
 
             // concat filter name
             if (filter != null)
@@ -92,6 +90,7 @@ namespace Dotmim.Sync.SqlServer.Builders
 
             return commandName;
         }
+
         public void AddCommandName(DbCommandType objectType, string name)
         {
             if (commandNames.ContainsKey(objectType))
@@ -99,12 +98,11 @@ namespace Dotmim.Sync.SqlServer.Builders
 
             commandNames.Add(objectType, name);
         }
+
         public string GetCommandName(DbCommandType objectType, SyncFilter filter = null)
         {
-            if (!commandNames.ContainsKey(objectType))
+            if (!commandNames.TryGetValue(objectType, out var commandName))
                 throw new Exception("Yous should provide a value for all DbCommandName");
-
-            var commandName = commandNames[objectType];
 
             // concat filter name
             if (filter != null)

--- a/Projects/Dotmim.Sync.Sqlite/Builders/SQLiteObjectNames.cs
+++ b/Projects/Dotmim.Sync.Sqlite/Builders/SQLiteObjectNames.cs
@@ -34,12 +34,11 @@ namespace Dotmim.Sync.Sqlite
 
             commandNames.Add(objectType, name);
         }
+
         public string GetCommandName(DbCommandType objectType, SyncFilter filter = null)
         {
-            if (!commandNames.ContainsKey(objectType))
+            if (!commandNames.TryGetValue(objectType, out var commandName))
                 throw new NotSupportedException($"Sqlite provider does not support the command type {objectType.ToString()}");
-
-            var commandName = commandNames[objectType];
 
             // concat filter name
             //if (filter != null)
@@ -48,7 +47,6 @@ namespace Dotmim.Sync.Sqlite
             return commandName;
         }
 
-
         public void AddTriggerName(DbTriggerType objectType, string name)
         {
             if (triggersNames.ContainsKey(objectType))
@@ -56,12 +54,11 @@ namespace Dotmim.Sync.Sqlite
 
             triggersNames.Add(objectType, name);
         }
+
         public string GetTriggerCommandName(DbTriggerType objectType, SyncFilter filter = null)
         {
-            if (!triggersNames.ContainsKey(objectType))
+            if (!triggersNames.TryGetValue(objectType, out var commandName))
                 throw new Exception("Yous should provide a value for all DbCommandName");
-
-            var commandName = triggersNames[objectType];
 
             //// concat filter name
             //if (filter != null)
@@ -69,8 +66,6 @@ namespace Dotmim.Sync.Sqlite
 
             return commandName;
         }
-
-
 
         public SqliteObjectNames(SyncTable tableDescription, ParserName tableName, ParserName trackingName, SyncSetup setup, string scopeName)
         {

--- a/Projects/Dotmim.Sync.Web.Client/Orchestrators/WebRemoteOrchestrator.cs
+++ b/Projects/Dotmim.Sync.Web.Client/Orchestrators/WebRemoteOrchestrator.cs
@@ -102,11 +102,7 @@ namespace Dotmim.Sync.Web.Client
         /// </summary>
         public void AddScopeParameter(string key, string value)
         {
-            if (this.ScopeParameters.ContainsKey(key))
-                this.ScopeParameters[key] = value;
-            else
-                this.ScopeParameters.Add(key, value);
-
+            this.ScopeParameters[key] = value;
         }
 
         /// <summary>
@@ -114,11 +110,7 @@ namespace Dotmim.Sync.Web.Client
         /// </summary>
         public void AddCustomHeader(string key, string value)
         {
-            if (this.CustomHeaders.ContainsKey(key))
-                this.CustomHeaders[key] = value;
-            else
-                this.CustomHeaders.Add(key, value);
-
+            this.CustomHeaders[key] = value;
         }
 
         /// <summary>

--- a/Projects/Dotmim.Sync.Web.Server/WebServerAgent.cs
+++ b/Projects/Dotmim.Sync.Web.Server/WebServerAgent.cs
@@ -1,4 +1,4 @@
-﻿using Dotmim.Sync.Batch;
+using Dotmim.Sync.Batch;
 using Dotmim.Sync.Builders;
 using Dotmim.Sync.Enumerations;
 using Dotmim.Sync.Serialization;
@@ -340,10 +340,8 @@ namespace Dotmim.Sync.Web.Server
         /// </summary>
         public virtual byte[] EnsureCompression(HttpRequest httpRequest, HttpResponse httpResponse, byte[] binaryData)
         {
-            string encoding = httpRequest.Headers["Accept-Encoding"];
-
             // Compress data if client accept Gzip / Deflate
-            if (!string.IsNullOrEmpty(encoding) && (encoding.Contains("gzip") || encoding.Contains("deflate")))
+            if (httpRequest.Headers.TryGetValue("Accept-Encoding", out var encoding) && (encoding.Contains("gzip") || encoding.Contains("deflate")))
             {
                 if (!httpResponse.Headers.ContainsKey("Content-Encoding"))
                     httpResponse.Headers.Add("Content-Encoding", "gzip");

--- a/Tests/Dotmim.Sync.Tests/HttpTests/HttpTests.cs
+++ b/Tests/Dotmim.Sync.Tests/HttpTests/HttpTests.cs
@@ -2229,8 +2229,7 @@ namespace Dotmim.Sync.Tests.IntegrationTests
                 // When Server Orchestrator send back the response, we will make an interruption
                 webServerAgent.OnHttpGettingRequest(args =>
                 {
-                    if (!interrupted.ContainsKey(args.HttpStep))
-                        interrupted.Add(args.HttpStep, false);
+                    interrupted.TryAdd(args.HttpStep, false);
 
                     // interrupt each step to see if it's working
                     if (!interrupted[args.HttpStep])
@@ -2300,8 +2299,7 @@ namespace Dotmim.Sync.Tests.IntegrationTests
                 // When Server Orchestrator send back the response, we will make an interruption
                 webServerAgent.OnHttpSendingResponse(args =>
                 {
-                    if (!interrupted.ContainsKey(args.HttpStep))
-                        interrupted.Add(args.HttpStep, false);
+                    interrupted.TryAdd(args.HttpStep, false);
 
                     // interrupt each step to see if it's working
                     if (!interrupted[args.HttpStep])


### PR DESCRIPTION
This is a continuation of https://github.com/Mimetis/Dotmim.Sync/pull/1015 

Add/Update logic can also avoid ContainsKey() lookups by simply assigning a value for a key via the indexer, as that will either add or update as needed.