### PR TITLE
Cache all DbCommands generated by adapters

### DIFF
--- a/Projects/Dotmim.Sync.Core/DbSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.Core/DbSyncAdapter.cs
@@ -1,4 +1,4 @@
-using Dotmim.Sync.Builders;
+﻿using Dotmim.Sync.Builders;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -13,6 +13,7 @@ namespace Dotmim.Sync
     /// </summary>
     public abstract class DbSyncAdapter
     {
+        protected static ConcurrentDictionary<string, (DbCommand, bool)> commandCache = new();
 
         /// <summary>
         /// Gets the table description
@@ -71,7 +72,7 @@ namespace Dotmim.Sync
         /// <summary>
         /// Gets a command from the current table in the adapter
         /// </summary>
-        public abstract (DbCommand Command, bool IsBatchCommand) GetCommand(DbCommandType commandType, SyncFilter filter = null);
+        public abstract (DbCommand Command, bool IsBatchCommand) GetCommand(DbConnection connection, DbCommandType commandType, SyncFilter filter = null);
 
         /// <summary>
         /// Adding a parameter value to a command
@@ -129,14 +130,15 @@ namespace Dotmim.Sync
             return command.Parameters[parameterName];
         }
 
-
         /// <summary>
         /// Execute a batch command
         /// </summary>
         public abstract Task ExecuteBatchCommandAsync(DbCommand cmd, Guid senderScopeId, IEnumerable<SyncRow> arrayItems, SyncTable schemaChangesTable,
                                                       SyncTable failedRows, long? lastTimestamp, DbConnection connection, DbTransaction transaction);
 
-
-
+        protected static string GetCacheKey(DbConnection connection, DbCommandType commandType, SyncFilter filter)
+        {
+            return $"{connection.Database}|{commandType}|{filter?.GetFilterName()}";
+        }
     }
 }

--- a/Projects/Dotmim.Sync.Core/DbSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.Core/DbSyncAdapter.cs
@@ -1,20 +1,9 @@
-﻿using Dotmim.Sync.Enumerations;
-using Dotmim.Sync.Manager;
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Data.Common;
-using System.Globalization;
-using System.Linq;
 using Dotmim.Sync.Builders;
-using System.Diagnostics;
-using System.ComponentModel;
-using System.Threading.Tasks;
-
-using System.Reflection;
+using System;
 using System.Collections.Concurrent;
-using System.Text;
-using System.Threading;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading.Tasks;
 
 namespace Dotmim.Sync
 {

--- a/Projects/Dotmim.Sync.Core/DbSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.Core/DbSyncAdapter.cs
@@ -17,7 +17,7 @@ namespace Dotmim.Sync
         /// <summary>
         /// Gets the table description
         /// </summary>
-        public SyncTable TableDescription { get; private set; }
+        public SyncTable TableDescription { get; }
 
         /// <summary>
         /// Gets the setup used 

--- a/Projects/Dotmim.Sync.Core/Orchestrators/Commands/BaseOrchestrator.Commands.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/Commands/BaseOrchestrator.Commands.cs
@@ -27,7 +27,7 @@ namespace Dotmim.Sync
             if (this.Provider != null && this.Provider.CanBeServerProvider) // Sqlite can't be server
                 filter = syncAdapter.TableDescription.GetFilter();
 
-            var (command, isBatch) = syncAdapter.GetCommand(commandType, filter);
+            var (command, isBatch) = syncAdapter.GetCommand(connection, commandType, filter);
 
             // IF we do not have any command associated, just return
             if (command == null)

--- a/Projects/Dotmim.Sync.PostgreSql/NpgsqlSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.PostgreSql/NpgsqlSyncAdapter.cs
@@ -1,19 +1,13 @@
-﻿using Dotmim.Sync.Builders;
+using Dotmim.Sync.Builders;
 using Dotmim.Sync.PostgreSql.Builders;
-using Newtonsoft.Json.Linq;
 using Npgsql;
 using NpgsqlTypes;
 using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Transactions;
-using static Npgsql.Replication.PgOutput.Messages.RelationMessage;
 
 namespace Dotmim.Sync.PostgreSql
 {

--- a/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
@@ -27,9 +27,9 @@ namespace Dotmim.Sync.SqlServer.Builders
         private static ConcurrentDictionary<string, List<SqlParameter>> derivingParameters
             = new ConcurrentDictionary<string, List<SqlParameter>>();
 
-        public static DateTime SqlDateMin = new DateTime(1753, 1, 1);
+        public static readonly DateTime SqlDateMin = new DateTime(1753, 1, 1);
+        public static readonly DateTime SqlSmallDateMin = new DateTime(1900, 1, 1);
 
-        public static DateTime SqlSmallDateMin = new DateTime(1900, 1, 1);
         public SqlObjectNames SqlObjectNames { get; set; }
         public SqlDbMetadata SqlMetadata { get; set; }
 

--- a/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
@@ -1,4 +1,4 @@
-using Dotmim.Sync.Builders;
+﻿using Dotmim.Sync.Builders;
 using Dotmim.Sync.SqlServer.Manager;
 using Microsoft.Data.SqlClient;
 using System;
@@ -23,8 +23,8 @@ namespace Dotmim.Sync.SqlServer.Builders
         public static readonly DateTime SqlDateMin = new DateTime(1753, 1, 1);
         public static readonly DateTime SqlSmallDateMin = new DateTime(1900, 1, 1);
 
-        public SqlObjectNames SqlObjectNames { get; set; }
-        public SqlDbMetadata SqlMetadata { get; set; }
+        public SqlObjectNames SqlObjectNames { get; }
+        public SqlDbMetadata SqlMetadata { get; }
 
         private readonly ParserName tableName;
         private readonly ParserName trackingName;

--- a/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
@@ -1,18 +1,13 @@
-﻿using Dotmim.Sync.Builders;
+using Dotmim.Sync.Builders;
 using Dotmim.Sync.SqlServer.Manager;
+using Microsoft.Data.SqlClient;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
-using Microsoft.Data.SqlClient;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Data.SqlClient.Server;
-using Dotmim.Sync.Enumerations;
 
 namespace Dotmim.Sync.SqlServer.Builders
 {

--- a/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
@@ -13,14 +13,12 @@ namespace Dotmim.Sync.SqlServer.Builders
 {
     public partial class SqlSyncAdapter : DbSyncAdapter
     {
-
         // Derive Parameters cache
         // Be careful, we can have collision between databases
         // this static class could be shared accross databases with same command name
         // but different table schema
         // So the string should contains the connection string as well
-        private static ConcurrentDictionary<string, List<SqlParameter>> derivingParameters
-            = new ConcurrentDictionary<string, List<SqlParameter>>();
+        private static ConcurrentDictionary<string, List<SqlParameter>> derivingParameters = new();
 
         public static readonly DateTime SqlDateMin = new DateTime(1753, 1, 1);
         public static readonly DateTime SqlSmallDateMin = new DateTime(1900, 1, 1);

--- a/Projects/Dotmim.Sync.Sqlite/SQLiteSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.Sqlite/SQLiteSyncAdapter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -23,13 +23,14 @@ namespace Dotmim.Sync.Sqlite
 
         public override (DbCommand, bool) GetCommand(DbCommandType commandType, SyncFilter filter = null)
         {
-            var command = new SqliteCommand();
-            string text;
-            text = this.sqliteObjectNames.GetCommandName(commandType, filter);
+            string text = this.sqliteObjectNames.GetCommandName(commandType, filter);
 
             // on Sqlite, everything is text :)
-            command.CommandType = CommandType.Text;
-            command.CommandText = text;
+            var command = new SqliteCommand
+            {
+                CommandType = CommandType.Text,
+                CommandText = text
+            };
 
             return (command, false);
         }


### PR DESCRIPTION
This uses a similar strategy to what was already used in the SqlSyncAdapter in the SQL Server project, with respect to the derived parameters cache.

The cache key includes the database name and the other two parameters of the GetCommand() function, and thus it is a simple case of memoization and is unlikely to fail.

Because the ConcurrentDictionary was made static, just like the one for the derived parameters, it needed to follow the notice in the comment there, that the key should include the database name. Which is why I added the DbConnection parameter to GetCommand()