### PR TITLE
use private setters for metadata

### DIFF
--- a/Projects/Dotmim.Sync.MySql/MySqlSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.MySql/MySqlSyncAdapter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -27,9 +27,8 @@ namespace Dotmim.Sync.MySql
 
     public class MySqlSyncAdapter : DbSyncAdapter
     {
-
-        public MySqlObjectNames MySqlObjectNames { get; set; }
-        public MySqlDbMetadata MySqlDbMetadata { get; set; }
+        public MySqlObjectNames MySqlObjectNames { get; }
+        public MySqlDbMetadata MySqlDbMetadata { get; }
 
         public MySqlSyncAdapter(SyncTable tableDescription, ParserName tableName, ParserName trackingName, SyncSetup setup, string scopeName) : base(tableDescription, setup, scopeName)
         {

--- a/Projects/Dotmim.Sync.PostgreSql/NpgsqlSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.PostgreSql/NpgsqlSyncAdapter.cs
@@ -41,7 +41,7 @@ namespace Dotmim.Sync.PostgreSql
         internal const string resetMetadataProcName = @"{0}.""{1}{2}reset""";
         private bool legacyTimestampBehavior = true;
 
-        public NpgsqlDbMetadata NpgsqlDbMetadata { get; private set; }
+        public NpgsqlDbMetadata NpgsqlDbMetadata { get; }
         public ParserName TableName { get; }
         public ParserName TrackingTableName { get; }
 

--- a/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
+++ b/Projects/Dotmim.Sync.SqlServer/SqlSyncAdapter.cs
@@ -30,8 +30,8 @@ namespace Dotmim.Sync.SqlServer.Builders
         public static DateTime SqlDateMin = new DateTime(1753, 1, 1);
 
         public static DateTime SqlSmallDateMin = new DateTime(1900, 1, 1);
-        public SqlObjectNames SqlObjectNames { get; set; }
-        public SqlDbMetadata SqlMetadata { get; set; }
+        public SqlObjectNames SqlObjectNames { get; }
+        public SqlDbMetadata SqlMetadata { get; }
 
         private readonly ParserName tableName;
         private readonly ParserName trackingName;


### PR DESCRIPTION
In my opinion we should modify these properties to have only private setters. That initialization should only happen via the constructor, since it seems very likely to break things.

There were no tests for that kind of scenario of changing those properties post-initialization, which is why I was able to cleanly remove the setters.

Removing these setters can simplify the assumptions of all the callers that consume the getters, and allow things like storing a  reference or caching, if we know that they will never be mutated.

Conversely, if using the setters is a supported scenario, then we should add tests around it. And it would be strange to only allow such a thing on some of the adapters, but not all of them, as is currently the case.