### PR TITLE
#1141 : SynchronousProgress<T> in WinUI 3/AppSdk app

### DIFF
--- a/Projects/Dotmim.Sync.Core/Interceptors/SynchronousProgress.cs
+++ b/Projects/Dotmim.Sync.Core/Interceptors/SynchronousProgress.cs
@@ -70,7 +70,7 @@ namespace Dotmim.Sync
             {
                 // Post the processing to the [....] context.
                 // (If T is a value type, it will get boxed here.)
-                m_synchronizationContext.Send(m_invokeHandlers, value);
+                m_synchronizationContext.Post(m_invokeHandlers, value);
             }
         }
 


### PR DESCRIPTION
See #1141 

If SynchronousProgress is used in a WinUI 3/AppSdk application an exception is thrown when the sync is started which tells:
"The send method is not supported, use Post instead."

Changing line 73 in /Projects/Dotmim.Sync.Core/Interceptors/SynchronousProgress.cs
m_synchronizationContext.Send(m_invokeHandlers, value);
to
m_synchronizationContext.Post(m_invokeHandlers, value);
and everything works fine.