### PR TITLE
use static JsonSerializer

### DIFF
--- a/Projects/Dotmim.Sync.Core/Serialization/ISerializer.cs
+++ b/Projects/Dotmim.Sync.Core/Serialization/ISerializer.cs
@@ -26,10 +26,6 @@ namespace Dotmim.Sync.Serialization
         Task<object> DeserializeAsync(Stream ms, Type type);
         Task<T> DeserializeAsync<T>(Stream ms);
 
-        Task<byte[]> SerializeAsync(object obj);
         Task<byte[]> SerializeAsync<T>(T obj);
     }
-
-
-
 }


### PR DESCRIPTION
Going along with my other PR https://github.com/Mimetis/Dotmim.Sync/pull/1022 we can safely assume that JsonSerializer is thread-safe, as per the advice of the library author James Newton-King.

A static serializer means we can avoid repeated object creation overhead

JsonSerializer is preferred over JObject because it is faster when we know the type ahead of time. Which we do.

This removes the SerializeAsync(object) overload because the generic version handles that perfectly.