### PR TITLE
Remove unused package

### DIFF
--- a/Projects/Dotmim.Sync.Core/Dotmim.Sync.Core.csproj
+++ b/Projects/Dotmim.Sync.Core/Dotmim.Sync.Core.csproj
@@ -80,7 +80,6 @@
 		<PackageReference Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Bcl.Build" Version="1.0.21" />
 		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.9.5" />
 		<PackageReference Include="Microsoft.Build.Tasks.Git" Version="8.0.0">
 			<PrivateAssets>all</PrivateAssets>

--- a/Projects/Dotmim.Sync.Core/packages.lock.json
+++ b/Projects/Dotmim.Sync.Core/packages.lock.json
@@ -11,12 +11,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Bcl.Build": {
-        "type": "Direct",
-        "requested": "[1.0.21, )",
-        "resolved": "1.0.21",
-        "contentHash": "sgHu4mIt0+NVGyI12Bj4hLPypNK55UOH+ologj2LqDCjxq3EbIxe/uAtHjY+fEwbE1dtsAHG8SXHf+V/EYbKTg=="
-      },
       "Microsoft.Build.Tasks.Core": {
         "type": "Direct",
         "requested": "[17.9.5, )",

--- a/Projects/Dotmim.Sync.MariaDB/packages.lock.json
+++ b/Projects/Dotmim.Sync.MariaDB/packages.lock.json
@@ -40,11 +40,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Bcl.Build": {
-        "type": "Transitive",
-        "resolved": "1.0.21",
-        "contentHash": "sgHu4mIt0+NVGyI12Bj4hLPypNK55UOH+ologj2LqDCjxq3EbIxe/uAtHjY+fEwbE1dtsAHG8SXHf+V/EYbKTg=="
-      },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
         "resolved": "17.9.5",
@@ -373,7 +368,6 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "[8.0.0, )",
-          "Microsoft.Bcl.Build": "[1.0.21, )",
           "Microsoft.Build.Tasks.Core": "[17.9.5, )",
           "Microsoft.CSharp": "[4.7.0, )",
           "Microsoft.Extensions.Logging": "[2.2.0, )",

--- a/Projects/Dotmim.Sync.MySql/packages.lock.json
+++ b/Projects/Dotmim.Sync.MySql/packages.lock.json
@@ -40,11 +40,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Bcl.Build": {
-        "type": "Transitive",
-        "resolved": "1.0.21",
-        "contentHash": "sgHu4mIt0+NVGyI12Bj4hLPypNK55UOH+ologj2LqDCjxq3EbIxe/uAtHjY+fEwbE1dtsAHG8SXHf+V/EYbKTg=="
-      },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
         "resolved": "17.9.5",
@@ -373,7 +368,6 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "[8.0.0, )",
-          "Microsoft.Bcl.Build": "[1.0.21, )",
           "Microsoft.Build.Tasks.Core": "[17.9.5, )",
           "Microsoft.CSharp": "[4.7.0, )",
           "Microsoft.Extensions.Logging": "[2.2.0, )",

--- a/Projects/Dotmim.Sync.PostgreSql/packages.lock.json
+++ b/Projects/Dotmim.Sync.PostgreSql/packages.lock.json
@@ -44,11 +44,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Bcl.Build": {
-        "type": "Transitive",
-        "resolved": "1.0.21",
-        "contentHash": "sgHu4mIt0+NVGyI12Bj4hLPypNK55UOH+ologj2LqDCjxq3EbIxe/uAtHjY+fEwbE1dtsAHG8SXHf+V/EYbKTg=="
-      },
       "Microsoft.Bcl.HashCode": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -408,7 +403,6 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "[8.0.0, )",
-          "Microsoft.Bcl.Build": "[1.0.21, )",
           "Microsoft.Build.Tasks.Core": "[17.9.5, )",
           "Microsoft.CSharp": "[4.7.0, )",
           "Microsoft.Extensions.Logging": "[2.2.0, )",

--- a/Projects/Dotmim.Sync.SqlServer.ChangeTracking/packages.lock.json
+++ b/Projects/Dotmim.Sync.SqlServer.ChangeTracking/packages.lock.json
@@ -58,11 +58,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Bcl.Build": {
-        "type": "Transitive",
-        "resolved": "1.0.21",
-        "contentHash": "sgHu4mIt0+NVGyI12Bj4hLPypNK55UOH+ologj2LqDCjxq3EbIxe/uAtHjY+fEwbE1dtsAHG8SXHf+V/EYbKTg=="
-      },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
         "resolved": "17.9.5",
@@ -634,7 +629,6 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "[8.0.0, )",
-          "Microsoft.Bcl.Build": "[1.0.21, )",
           "Microsoft.Build.Tasks.Core": "[17.9.5, )",
           "Microsoft.CSharp": "[4.7.0, )",
           "Microsoft.Extensions.Logging": "[2.2.0, )",
@@ -645,7 +639,7 @@
       "dotmim.sync.sqlserver": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.0, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.Data.SqlClient": "[5.2.1, )"
         }
       }
@@ -868,11 +862,6 @@
         "resolved": "6.0.0",
         "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
       },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
-      },
       "System.ClientModel": {
         "type": "Transitive",
         "resolved": "1.0.0",
@@ -1031,7 +1020,7 @@
       "dotmim.sync.sqlserver": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.0, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.Data.SqlClient": "[5.2.1, )"
         }
       }
@@ -1246,11 +1235,6 @@
         "resolved": "1.0.0",
         "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
       },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
-      },
       "System.ClientModel": {
         "type": "Transitive",
         "resolved": "1.0.0",
@@ -1380,7 +1364,7 @@
       "dotmim.sync.sqlserver": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.0, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.Data.SqlClient": "[5.2.1, )"
         }
       }

--- a/Projects/Dotmim.Sync.SqlServer/packages.lock.json
+++ b/Projects/Dotmim.Sync.SqlServer/packages.lock.json
@@ -82,11 +82,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Bcl.Build": {
-        "type": "Transitive",
-        "resolved": "1.0.21",
-        "contentHash": "sgHu4mIt0+NVGyI12Bj4hLPypNK55UOH+ologj2LqDCjxq3EbIxe/uAtHjY+fEwbE1dtsAHG8SXHf+V/EYbKTg=="
-      },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
         "resolved": "17.9.5",
@@ -635,7 +630,6 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "[8.0.0, )",
-          "Microsoft.Bcl.Build": "[1.0.21, )",
           "Microsoft.Build.Tasks.Core": "[17.9.5, )",
           "Microsoft.CSharp": "[4.7.0, )",
           "Microsoft.Extensions.Logging": "[2.2.0, )",
@@ -862,11 +856,6 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "System.ClientModel": {
         "type": "Transitive",
@@ -1234,11 +1223,6 @@
         "type": "Transitive",
         "resolved": "1.0.0",
         "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "System.ClientModel": {
         "type": "Transitive",

--- a/Projects/Dotmim.Sync.Sqlite/packages.lock.json
+++ b/Projects/Dotmim.Sync.Sqlite/packages.lock.json
@@ -39,11 +39,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Bcl.Build": {
-        "type": "Transitive",
-        "resolved": "1.0.21",
-        "contentHash": "sgHu4mIt0+NVGyI12Bj4hLPypNK55UOH+ologj2LqDCjxq3EbIxe/uAtHjY+fEwbE1dtsAHG8SXHf+V/EYbKTg=="
-      },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
         "resolved": "17.9.5",
@@ -410,7 +405,6 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "[8.0.0, )",
-          "Microsoft.Bcl.Build": "[1.0.21, )",
           "Microsoft.Build.Tasks.Core": "[17.9.5, )",
           "Microsoft.CSharp": "[4.7.0, )",
           "Microsoft.Extensions.Logging": "[2.2.0, )",

--- a/Projects/Dotmim.Sync.Web.Client/packages.lock.json
+++ b/Projects/Dotmim.Sync.Web.Client/packages.lock.json
@@ -57,11 +57,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Bcl.Build": {
-        "type": "Transitive",
-        "resolved": "1.0.21",
-        "contentHash": "sgHu4mIt0+NVGyI12Bj4hLPypNK55UOH+ologj2LqDCjxq3EbIxe/uAtHjY+fEwbE1dtsAHG8SXHf+V/EYbKTg=="
-      },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
         "resolved": "17.9.5",
@@ -403,7 +398,6 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "[8.0.0, )",
-          "Microsoft.Bcl.Build": "[1.0.21, )",
           "Microsoft.Build.Tasks.Core": "[17.9.5, )",
           "Microsoft.CSharp": "[4.7.0, )",
           "Microsoft.Extensions.Logging": "[2.2.0, )",

--- a/Projects/Dotmim.Sync.Web.Server/packages.lock.json
+++ b/Projects/Dotmim.Sync.Web.Server/packages.lock.json
@@ -132,11 +132,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Bcl.Build": {
-        "type": "Transitive",
-        "resolved": "1.0.21",
-        "contentHash": "sgHu4mIt0+NVGyI12Bj4hLPypNK55UOH+ologj2LqDCjxq3EbIxe/uAtHjY+fEwbE1dtsAHG8SXHf+V/EYbKTg=="
-      },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
         "resolved": "17.9.5",
@@ -482,7 +477,6 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "[8.0.0, )",
-          "Microsoft.Bcl.Build": "[1.0.21, )",
           "Microsoft.Build.Tasks.Core": "[17.9.5, )",
           "Microsoft.CSharp": "[4.7.0, )",
           "Microsoft.Extensions.Logging": "[2.2.0, )",
@@ -493,7 +487,7 @@
       "dotmim.sync.web.client": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.Extensions.Features": "[6.0.0, )",
           "Microsoft.Net.Http.Headers": "[2.2.8, )"
@@ -649,7 +643,7 @@
       "dotmim.sync.web.client": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.Extensions.Features": "[6.0.0, )"
         }
@@ -758,7 +752,7 @@
       "dotmim.sync.web.client": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.Extensions.Features": "[8.0.6, )",
           "Microsoft.Net.Http.Headers": "[8.0.6, )"
         }

--- a/Tests/Dotmim.Sync.Tests/packages.lock.json
+++ b/Tests/Dotmim.Sync.Tests/packages.lock.json
@@ -189,11 +189,6 @@
         "resolved": "8.0.0",
         "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
       },
-      "Microsoft.Bcl.Build": {
-        "type": "Transitive",
-        "resolved": "1.0.21",
-        "contentHash": "sgHu4mIt0+NVGyI12Bj4hLPypNK55UOH+ologj2LqDCjxq3EbIxe/uAtHjY+fEwbE1dtsAHG8SXHf+V/EYbKTg=="
-      },
       "Microsoft.Bcl.HashCode": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -1025,7 +1020,6 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "[8.0.0, )",
-          "Microsoft.Bcl.Build": "[1.0.21, )",
           "Microsoft.Build.Tasks.Core": "[17.9.5, )",
           "Microsoft.CSharp": "[4.7.0, )",
           "Microsoft.Extensions.Logging": "[2.2.0, )",
@@ -1036,48 +1030,48 @@
       "dotmim.sync.mariadb": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "MySqlConnector": "[0.69.10, )"
         }
       },
       "dotmim.sync.mysql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "MySqlConnector": "[0.69.10, )"
         }
       },
       "dotmim.sync.postgresql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Npgsql": "[8.0.3, )"
         }
       },
       "dotmim.sync.sqlite": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.Data.Sqlite": "[8.0.6, )"
         }
       },
       "dotmim.sync.sqlserver": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.Data.SqlClient": "[5.2.1, )"
         }
       },
       "dotmim.sync.sqlserver.changetracking": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.SqlServer": "[1.0.2, )"
+          "Dotmim.Sync.SqlServer": "[1.1.0, )"
         }
       },
       "dotmim.sync.web.client": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.Extensions.Features": "[6.0.0, )",
           "Microsoft.Net.Http.Headers": "[2.2.8, )"
@@ -1086,7 +1080,7 @@
       "dotmim.sync.web.server": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Web.Client": "[1.0.2, )",
+          "Dotmim.Sync.Web.Client": "[1.1.0, )",
           "Microsoft.AspNetCore.Http.Abstractions": "[2.2.0, )",
           "Microsoft.AspNetCore.Http.Extensions": "[2.2.0, )",
           "Microsoft.Extensions.Caching.Abstractions": "[3.1.32, )",
@@ -1820,48 +1814,48 @@
       "dotmim.sync.mariadb": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "MySqlConnector": "[2.3.7, )"
         }
       },
       "dotmim.sync.mysql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "MySqlConnector": "[2.3.7, )"
         }
       },
       "dotmim.sync.postgresql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Npgsql": "[8.0.3, )"
         }
       },
       "dotmim.sync.sqlite": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.Data.Sqlite": "[8.0.6, )"
         }
       },
       "dotmim.sync.sqlserver": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.Data.SqlClient": "[5.2.1, )"
         }
       },
       "dotmim.sync.sqlserver.changetracking": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.SqlServer": "[1.0.2, )"
+          "Dotmim.Sync.SqlServer": "[1.1.0, )"
         }
       },
       "dotmim.sync.web.client": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.Extensions.Features": "[6.0.0, )"
         }
@@ -1869,7 +1863,7 @@
       "dotmim.sync.web.server": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Web.Client": "[1.0.2, )",
+          "Dotmim.Sync.Web.Client": "[1.1.0, )",
           "System.Text.Json": "[8.0.3, )"
         }
       }
@@ -2473,48 +2467,48 @@
       "dotmim.sync.mariadb": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "MySqlConnector": "[2.3.7, )"
         }
       },
       "dotmim.sync.mysql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "MySqlConnector": "[2.3.7, )"
         }
       },
       "dotmim.sync.postgresql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Npgsql": "[8.0.3, )"
         }
       },
       "dotmim.sync.sqlite": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.Data.Sqlite": "[8.0.6, )"
         }
       },
       "dotmim.sync.sqlserver": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.Data.SqlClient": "[5.2.1, )"
         }
       },
       "dotmim.sync.sqlserver.changetracking": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.SqlServer": "[1.0.2, )"
+          "Dotmim.Sync.SqlServer": "[1.1.0, )"
         }
       },
       "dotmim.sync.web.client": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.0.2, )",
+          "Dotmim.Sync.Core": "[1.1.0, )",
           "Microsoft.Extensions.Features": "[8.0.6, )",
           "Microsoft.Net.Http.Headers": "[8.0.6, )"
         }
@@ -2522,7 +2516,7 @@
       "dotmim.sync.web.server": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Web.Client": "[1.0.2, )",
+          "Dotmim.Sync.Web.Client": "[1.1.0, )",
           "System.Text.Json": "[8.0.3, )"
         }
       }


### PR DESCRIPTION
Microsoft.Bcl.Build doesn't seem to be necessary for .NET Standard 2.0 and above

This is a one-line change but the lockfiles needed to be regenerated.