### PR TITLE
fix test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,3 +274,6 @@ __pycache__/
 /.vscode
 
 /docs/_build
+
+# InferSharp config file
+.infersharpconfig

--- a/Projects/Dotmim.Sync.Core/Serialization/ObjectToInferredTypesConverter.cs
+++ b/Projects/Dotmim.Sync.Core/Serialization/ObjectToInferredTypesConverter.cs
@@ -17,7 +17,7 @@ namespace Dotmim.Sync.Serialization
                 JsonTokenType.False => false,
                 JsonTokenType.Number when reader.TryGetInt64(out long l) => l,
                 JsonTokenType.Number => reader.GetDouble(),
-                JsonTokenType.String when reader.TryGetDateTime(out DateTime datetime) => datetime,
+                JsonTokenType.String when reader.TryGetDateTimeOffset(out DateTimeOffset dto) => dto,
                 JsonTokenType.String => reader.GetString()!,
                 _ => JsonDocument.ParseValue(ref reader).RootElement.Clone()
             };


### PR DESCRIPTION
We can see from the referenced code below that the correct data type for the 9th column is `DateTime`

```csharp
public static SyncTable GetSimpleSyncTable(int rowsCount = 1)
{
    SyncTable tCustomer = new SyncTable("Customer");
    tCustomer.Columns.Add(new SyncColumn("ID", typeof(Guid)));
    tCustomer.Columns.Add(new SyncColumn("Name", typeof(string)));
    tCustomer.Columns.Add(new SyncColumn("Column_Int16", typeof(short)));
    tCustomer.Columns.Add(new SyncColumn("Column_Int32", typeof(int)));
    tCustomer.Columns.Add(new SyncColumn("Column_Int64", typeof(long)));
    tCustomer.Columns.Add(new SyncColumn("Column_UInt16", typeof(ushort)));
    tCustomer.Columns.Add(new SyncColumn("Column_UInt32", typeof(uint)));
    tCustomer.Columns.Add(new SyncColumn("Column_UInt64", typeof(ulong)));
    tCustomer.Columns.Add(new SyncColumn("Column_DateTime", typeof(DateTime)));
    tCustomer.Columns.Add(new SyncColumn("Column_DateTimeOffset", typeof(DateTimeOffset)));
```

The rest of the types in the test aren't all matching, though. Should they be?