### PR TITLE
use params

### DIFF
--- a/Tests/Dotmim.Sync.Tests/Misc/DatabaseTest.cs
+++ b/Tests/Dotmim.Sync.Tests/Misc/DatabaseTest.cs
@@ -64,8 +64,8 @@ namespace Dotmim.Sync.Tests.Misc
             var salesSchemaWithDot = string.IsNullOrEmpty(salesSchema) ? string.Empty : $"{salesSchema}.";
 
             // Filter columns
-            setup.Tables["Customer"].Columns.AddRange(new string[] { "CustomerID", "EmployeeID", "NameStyle", "FirstName", "LastName" });
-            setup.Tables["Address"].Columns.AddRange(new string[] { "AddressID", "AddressLine1", "City", "PostalCode" });
+            setup.Tables["Customer"].Columns.AddRange("CustomerID", "EmployeeID", "NameStyle", "FirstName", "LastName");
+            setup.Tables["Address"].Columns.AddRange("AddressID", "AddressLine1", "City", "PostalCode");
 
             // Filters clause
 

--- a/Tests/Dotmim.Sync.Tests/TcpTests/TcpFilterTests.cs
+++ b/Tests/Dotmim.Sync.Tests/TcpTests/TcpFilterTests.cs
@@ -636,10 +636,10 @@ namespace Dotmim.Sync.Tests.IntegrationTests
                 await clientProvider.DropAllTablesAsync(true);
 
             var options = new SyncOptions { DisableConstraintsOnApplyChanges = true };
-            setup = new SyncSetup(new string[] { "Customer" });
+            setup = new SyncSetup("Customer");
 
             // Filtered columns. 
-            setup.Tables["Customer"].Columns.AddRange(new string[] { "CustomerID", "EmployeeID", "NameStyle", "FirstName", "LastName" });
+            setup.Tables["Customer"].Columns.AddRange("CustomerID", "EmployeeID", "NameStyle", "FirstName", "LastName");
             setup.Filters.Add("Customer", "EmployeeID");
 
             // Execute a sync on all clients and check results

--- a/Tests/Dotmim.Sync.Tests/TcpTests/TcpTests.ScenarioTests.cs
+++ b/Tests/Dotmim.Sync.Tests/TcpTests/TcpTests.ScenarioTests.cs
@@ -89,8 +89,7 @@ namespace Dotmim.Sync.Tests.IntegrationTests
             // Note we are not including the [Attribute With Space] column
 
             var setupV1 = new SyncSetup(productCategoryTable.GetFullName());
-            setupV1.Tables[productCategoryTable.GetFullName()].Columns.AddRange(
-                new string[] { "ProductCategoryId", "Name", "rowguid", "ModifiedDate" });
+            setupV1.Tables[productCategoryTable.GetFullName()].Columns.AddRange("ProductCategoryId", "Name", "rowguid", "ModifiedDate");
 
             int productCategoryRowsCount = 0;
             await using (var readCtx = new AdventureWorksContext(serverProvider))
@@ -111,8 +110,7 @@ namespace Dotmim.Sync.Tests.IntegrationTests
             // Creating a new scope called "v2" on server
             var setupV2 = new SyncSetup(productCategoryTable.GetFullName(), productTable.GetFullName());
 
-            setupV2.Tables[productCategoryTable.GetFullName()].Columns.AddRange(
-            new string[] { "ProductCategoryId", "Name", "rowguid", "ModifiedDate", "Attribute With Space" });
+            setupV2.Tables[productCategoryTable.GetFullName()].Columns.AddRange("ProductCategoryId", "Name", "rowguid", "ModifiedDate", "Attribute With Space");
 
             var serverScope = await remoteOrchestrator.ProvisionAsync("v2", setupV2);
 
@@ -196,8 +194,7 @@ namespace Dotmim.Sync.Tests.IntegrationTests
             // Note we are not including the [Attribute With Space] column
 
             var setupV1 = new SyncSetup(productCategoryTable.GetFullName());
-            setupV1.Tables[productCategoryTable.GetFullName()].Columns.AddRange(
-                new string[] { "ProductCategoryId", "ParentProductCategoryId", "Name", "rowguid", "ModifiedDate" });
+            setupV1.Tables[productCategoryTable.GetFullName()].Columns.AddRange("ProductCategoryId", "ParentProductCategoryId", "Name", "rowguid", "ModifiedDate");
 
             int productCategoryRowsCount = 0;
             await using (var readCtx = new AdventureWorksContext(serverProvider))
@@ -218,8 +215,7 @@ namespace Dotmim.Sync.Tests.IntegrationTests
             // Creating a new scope called "v2" on server
             var setupV2 = new SyncSetup(productCategoryTable.GetFullName(), productTable.GetFullName());
 
-            setupV2.Tables[productCategoryTable.GetFullName()].Columns.AddRange(
-            new string[] { "ProductCategoryId", "ParentProductCategoryId", "Name", "rowguid", "ModifiedDate", "Attribute With Space" });
+            setupV2.Tables[productCategoryTable.GetFullName()].Columns.AddRange("ProductCategoryId", "ParentProductCategoryId", "Name", "rowguid", "ModifiedDate", "Attribute With Space");
 
             var serverScopeV2 = await remoteOrchestrator.ProvisionAsync("v2", setupV2);
 
@@ -326,8 +322,9 @@ namespace Dotmim.Sync.Tests.IntegrationTests
             // --------------------------
             // Step 1: Create a default scope and Sync clients
             // Note we are not including the [Attribute With Space] column
-            var setup = new SyncSetup(new string[] { productCategoryTableName });
-            setup.Tables[productCategoryTableName].Columns.AddRange("ProductCategoryId", "Name", "ParentProductCategoryId", "rowguid", "ModifiedDate");
+            var setup = new SyncSetup(productCategoryTableName);
+            setup.Tables[productCategoryTableName].Columns.AddRange(
+                "ProductCategoryId", "Name", "ParentProductCategoryId", "rowguid", "ModifiedDate");
 
             // Counting product categories & products
             int productCategoryRowsCount = 0;
@@ -354,7 +351,7 @@ namespace Dotmim.Sync.Tests.IntegrationTests
 
             // Adding a new scope on the server with this new column and a new table
             // Creating a new scope called "V1" on server
-            var setupV1 = new SyncSetup(new string[] { productCategoryTableName, productTableName });
+            var setupV1 = new SyncSetup(productCategoryTableName, productTableName);
 
             setupV1.Tables[productCategoryTableName].Columns.AddRange(
                 "ProductCategoryId", "Name", "ParentProductCategoryId", "rowguid", "ModifiedDate", "Attribute With Space");
@@ -493,9 +490,9 @@ namespace Dotmim.Sync.Tests.IntegrationTests
             var productCategoryTable = setup.Tables.First(t => t.TableName == "ProductCategory");
             var productTable = setup.Tables.First(t => t.TableName == "Product");
 
-            var setupV1 = new SyncSetup(new string[] { productCategoryTable.GetFullName() });
+            var setupV1 = new SyncSetup(productCategoryTable.GetFullName());
             setupV1.Tables[productCategoryTable.GetFullName()].Columns.AddRange(
-                new string[] { "ProductCategoryId", "Name", "rowguid", "ModifiedDate" });
+                "ProductCategoryId", "Name", "rowguid", "ModifiedDate");
 
             int productCategoryRowsCount = 0;
             await using (var readCtx = new AdventureWorksContext(serverProvider))
@@ -515,7 +512,8 @@ namespace Dotmim.Sync.Tests.IntegrationTests
             // Editing the current scope on the server with this new column and a new table
             setupV1.Tables.Add(productTable.GetFullName());
             setupV1.Tables[productCategoryTable.GetFullName()].Columns.Clear();
-            setupV1.Tables[productCategoryTable.GetFullName()].Columns.AddRange("ProductCategoryId", "Name", "rowguid", "ModifiedDate", "Attribute With Space");
+            setupV1.Tables[productCategoryTable.GetFullName()].Columns.AddRange(
+                "ProductCategoryId", "Name", "rowguid", "ModifiedDate", "Attribute With Space");
 
             // overwrite the setup
             var serverScope = await remoteOrchestrator.ProvisionAsync("v1", setupV1, overwrite: true);
@@ -592,9 +590,9 @@ namespace Dotmim.Sync.Tests.IntegrationTests
             var productCategoryTable = setup.Tables.First(t => t.TableName == "ProductCategory");
             var productTable = setup.Tables.First(t => t.TableName == "Product");
 
-            var setupV1 = new SyncSetup(new string[] { productCategoryTable.GetFullName() });
+            var setupV1 = new SyncSetup(productCategoryTable.GetFullName());
             setupV1.Tables[productCategoryTable.GetFullName()].Columns.AddRange(
-                new string[] { "ProductCategoryId", "Name", "rowguid", "ModifiedDate" });
+                "ProductCategoryId", "Name", "rowguid", "ModifiedDate");
 
             int productCategoryRowsCount = 0;
             await using (var readCtx = new AdventureWorksContext(serverProvider))
@@ -614,7 +612,8 @@ namespace Dotmim.Sync.Tests.IntegrationTests
             // Editing the current scope on the server with this new column and a new table
             setupV1.Tables.Add(productTable.GetFullName());
             setupV1.Tables[productCategoryTable.GetFullName()].Columns.Clear();
-            setupV1.Tables[productCategoryTable.GetFullName()].Columns.AddRange("ProductCategoryId", "Name", "rowguid", "ModifiedDate", "Attribute With Space");
+            setupV1.Tables[productCategoryTable.GetFullName()].Columns.AddRange(
+                "ProductCategoryId", "Name", "rowguid", "ModifiedDate", "Attribute With Space");
 
             // overwrite the setup
             var serverScope = await remoteOrchestrator.ProvisionAsync("v1", setupV1, overwrite: true);

--- a/Tests/Dotmim.Sync.Tests/TcpTests/TcpTests.cs
+++ b/Tests/Dotmim.Sync.Tests/TcpTests/TcpTests.cs
@@ -388,7 +388,7 @@ namespace Dotmim.Sync.Tests.IntegrationTests
             var badSetup = new SyncSetup("Employee");
 
             // Add a malformatted column name
-            badSetup.Tables["Employee"].Columns.AddRange(new string[] { "EmployeeID", "FirstName", "LastNam" });
+            badSetup.Tables["Employee"].Columns.AddRange("EmployeeID", "FirstName", "LastNam");
 
             // Execute a sync on all clients and check results
             foreach (var clientProvider in clientsProvider)

--- a/Tests/Dotmim.Sync.Tests/UnitTests/Interceptors/Interceptors.Tables.Tests.cs
+++ b/Tests/Dotmim.Sync.Tests/UnitTests/Interceptors/Interceptors.Tables.Tests.cs
@@ -31,7 +31,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             clientProvider = HelperDatabase.GetSyncProvider(clientProviderType, dbName, clientProvider.UseFallbackSchema());
 
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
 
             var table = new SyncTable("Product", "SalesLT");
             var colID = new SyncColumn("ID", typeof(Guid));
@@ -88,7 +88,7 @@ namespace Dotmim.Sync.Tests.UnitTests
         public async Task Table_Exists()
         {
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
-            var setup = new SyncSetup(new string[] { "SalesLT.Product", "SalesLT.ProductCategory" });
+            var setup = new SyncSetup("SalesLT.Product", "SalesLT.ProductCategory");
 
             var table = new SyncTable("Product", "SalesLT");
             var colID = new SyncColumn("ID", typeof(Guid));
@@ -126,7 +126,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             clientProvider = HelperDatabase.GetSyncProvider(clientProviderType, dbName, clientProvider.UseFallbackSchema());
 
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
 
             // Overwrite existing table with this new one
             var table = new SyncTable("Product", "SalesLT");
@@ -193,7 +193,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
-            var setup = new SyncSetup(new string[] { "SalesLT.ProductCategory", "SalesLT.ProductModel", "SalesLT.Product", "Posts" });
+            var setup = new SyncSetup("SalesLT.ProductCategory", "SalesLT.ProductModel", "SalesLT.Product", "Posts");
 
             var serverScope = await remoteOrchestrator.GetScopeInfoAsync(setup);
 

--- a/Tests/Dotmim.Sync.Tests/UnitTests/Interceptors/Interceptors.TrackingTables.Tests.cs
+++ b/Tests/Dotmim.Sync.Tests/UnitTests/Interceptors/Interceptors.TrackingTables.Tests.cs
@@ -26,7 +26,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" })
+            var setup = new SyncSetup("SalesLT.Product")
             {
                 TrackingTablesPrefix = "t_",
                 TrackingTablesSuffix = "_t"
@@ -71,7 +71,7 @@ namespace Dotmim.Sync.Tests.UnitTests
         {
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
-            var setup = new SyncSetup(new string[] { "SalesLT.Product", "SalesLT.ProductCategory" });
+            var setup = new SyncSetup("SalesLT.Product", "SalesLT.ProductCategory");
             setup.TrackingTablesPrefix = "t_";
             setup.TrackingTablesSuffix = "_t";
 
@@ -94,8 +94,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
             
-            var setup = new SyncSetup(new string[]
-            { "SalesLT.ProductCategory", "SalesLT.ProductModel", "SalesLT.Product", "Posts" })
+            var setup = new SyncSetup("SalesLT.ProductCategory", "SalesLT.ProductModel", "SalesLT.Product", "Posts")
             {
                 TrackingTablesPrefix = "t_",
                 TrackingTablesSuffix = "_t"
@@ -152,7 +151,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
 
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
             setup.TrackingTablesPrefix = "t_";
             setup.TrackingTablesSuffix = "_t";
 
@@ -197,7 +196,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
             setup.TrackingTablesPrefix = "t_";
             setup.TrackingTablesSuffix = "_t";
 
@@ -242,7 +241,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
-            var setup = new SyncSetup(new string[] { "SalesLT.ProductCategory", "SalesLT.ProductModel", "SalesLT.Product", "Posts" });
+            var setup = new SyncSetup("SalesLT.ProductCategory", "SalesLT.ProductModel", "SalesLT.Product", "Posts");
             setup.TrackingTablesPrefix = "t_";
             setup.TrackingTablesSuffix = "_t";
 

--- a/Tests/Dotmim.Sync.Tests/UnitTests/Interceptors/Interceptors.Triggers.Tests.cs
+++ b/Tests/Dotmim.Sync.Tests/UnitTests/Interceptors/Interceptors.Triggers.Tests.cs
@@ -27,7 +27,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
 
             // 1) create a console logger
             //var loggerFactory = LoggerFactory.Create(builder => { builder.AddDebug().SetMinimumLevel(LogLevel.Debug); });
@@ -73,7 +73,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
 
             var scopeInfo = await remoteOrchestrator.GetScopeInfoAsync(setup);
 
@@ -93,7 +93,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
 
             var scopeInfo = await remoteOrchestrator.GetScopeInfoAsync(setup);
 
@@ -135,7 +135,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
 
             var scopeInfo = await remoteOrchestrator.GetScopeInfoAsync(setup);
 
@@ -184,7 +184,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
 
             var scopeInfo = await remoteOrchestrator.GetScopeInfoAsync(setup);
 
@@ -233,7 +233,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
 
             var scopeInfo = await remoteOrchestrator.GetScopeInfoAsync(setup);
 
@@ -283,7 +283,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var localOrchestrator = new LocalOrchestrator(clientProvider, options);
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
 
             var scopeInfo = await remoteOrchestrator.GetScopeInfoAsync(setup);
 

--- a/Tests/Dotmim.Sync.Tests/UnitTests/Orchestrators/RemoteOrchestrator.StoredProcedures.Tests.cs
+++ b/Tests/Dotmim.Sync.Tests/UnitTests/Orchestrators/RemoteOrchestrator.StoredProcedures.Tests.cs
@@ -25,7 +25,7 @@ namespace Dotmim.Sync.Tests.UnitTests
         public async Task RemoteOrchestrator_StoredProcedure_ShouldCreate()
         {
             var scopeName = "scope";
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" })
+            var setup = new SyncSetup("SalesLT.Product")
             {
                 StoredProceduresPrefix = "sp_",
                 StoredProceduresSuffix = "_sp"
@@ -56,7 +56,7 @@ namespace Dotmim.Sync.Tests.UnitTests
         public async Task RemoteOrchestrator_StoredProcedure_ShouldOverwrite()
         {
             var scopeName = "scope";
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" })
+            var setup = new SyncSetup("SalesLT.Product")
             {
                 StoredProceduresPrefix = "sp_",
                 StoredProceduresSuffix = "_sp"
@@ -89,7 +89,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var scopeName = "scope";
 
             var options = new SyncOptions();
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" })
+            var setup = new SyncSetup("SalesLT.Product")
             {
                 StoredProceduresPrefix = "sp_",
                 StoredProceduresSuffix = "_sp"
@@ -121,7 +121,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var scopeName = "scope";
 
             var options = new SyncOptions();
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" })
+            var setup = new SyncSetup("SalesLT.Product")
             {
                 StoredProceduresPrefix = "sp_",
                 StoredProceduresSuffix = "_sp"
@@ -143,7 +143,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var scopeName = "scope";
 
             var options = new SyncOptions();
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" })
+            var setup = new SyncSetup("SalesLT.Product")
             {
                 StoredProceduresPrefix = "sp_",
                 StoredProceduresSuffix = "_sp"

--- a/Tests/Dotmim.Sync.Tests/UnitTests/Orchestrators/RemoteOrchestrator.Tests.cs
+++ b/Tests/Dotmim.Sync.Tests/UnitTests/Orchestrators/RemoteOrchestrator.Tests.cs
@@ -190,7 +190,7 @@ namespace Dotmim.Sync.Tests.UnitTests
         {
             var tables = new string[] { "Customer", "Address", "CustomerAddress" };
             var setup = new SyncSetup(tables);
-            setup.Tables["Customer"].Columns.AddRange(new string[] { "CustomerID", "FirstName", "LastName", "CompanyName" });
+            setup.Tables["Customer"].Columns.AddRange("CustomerID", "FirstName", "LastName", "CompanyName");
 
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
             var scopeInfo = await remoteOrchestrator.GetScopeInfoAsync(setup);
@@ -207,7 +207,7 @@ namespace Dotmim.Sync.Tests.UnitTests
         {
             var tables = new string[] { "Customer", "Address", "CustomerAddress" };
             var setup = new SyncSetup(tables);
-            setup.Tables["Customer"].Columns.AddRange(new string[] { "FirstName", "LastName", "CompanyName" });
+            setup.Tables["Customer"].Columns.AddRange("FirstName", "LastName", "CompanyName");
 
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
@@ -225,7 +225,7 @@ namespace Dotmim.Sync.Tests.UnitTests
         {
             var tables = new string[] { "Customer", "Address", "CustomerAddress" };
             var setup = new SyncSetup(tables);
-            setup.Tables["Customer"].Columns.AddRange(new string[] { "FirstName", "LastName", "CompanyName", "BADCOLUMN" });
+            setup.Tables["Customer"].Columns.AddRange("FirstName", "LastName", "CompanyName", "BADCOLUMN");
 
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 
@@ -260,7 +260,7 @@ namespace Dotmim.Sync.Tests.UnitTests
         public async Task RemoteOrchestrator_Provision_SchemaCreated_If_SetupHasTables()
         {
             var options = new SyncOptions();
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
             var scopeName = "scope";
 
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
@@ -280,7 +280,7 @@ namespace Dotmim.Sync.Tests.UnitTests
         {
             var scopeName = "scope";
 
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" })
+            var setup = new SyncSetup("SalesLT.Product")
             {
                 StoredProceduresPrefix = "s",
                 StoredProceduresSuffix = "proc"
@@ -320,7 +320,7 @@ namespace Dotmim.Sync.Tests.UnitTests
         [Fact]
         public async Task RemoteOrchestrator_Provision_ShouldCreate_StoredProcedures_WithDefaultScopeName()
         {
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" })
+            var setup = new SyncSetup("SalesLT.Product")
             {
                 StoredProceduresPrefix = "s",
                 StoredProceduresSuffix = "proc"
@@ -364,7 +364,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var scopeName = "scope";
 
             var options = new SyncOptions();
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
 
             var schema = new SyncSet();
             var table = new SyncTable("Product", "SalesLT");
@@ -399,7 +399,7 @@ namespace Dotmim.Sync.Tests.UnitTests
         public async Task RemoteOrchestrator_Provision_ShouldFails_If_SetupTable_DoesNotExist()
         {
             var scopeName = "scope";
-            var setup = new SyncSetup(new string[] { "SalesLT.badTable" });
+            var setup = new SyncSetup("SalesLT.badTable");
 
             var remoteOrchestrator = new RemoteOrchestrator(serverProvider, options);
 

--- a/Tests/Dotmim.Sync.Tests/UnitTests/Orchestrators/RemoteOrchestrator.Triggers.Tests.cs
+++ b/Tests/Dotmim.Sync.Tests/UnitTests/Orchestrators/RemoteOrchestrator.Triggers.Tests.cs
@@ -24,7 +24,7 @@ namespace Dotmim.Sync.Tests.UnitTests
         public async Task RemoteOrchestrator_Provision_ShouldCreate_Triggers()
         {
             var scopeName = "scope";
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" })
+            var setup = new SyncSetup("SalesLT.Product")
             {
                 TrackingTablesSuffix = "sync",
                 TrackingTablesPrefix = "trck",
@@ -66,7 +66,7 @@ namespace Dotmim.Sync.Tests.UnitTests
         public async Task RemoteOrchestrator_Trigger_ShouldCreate()
         {
             var scopeName = "scope";
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" })
+            var setup = new SyncSetup("SalesLT.Product")
             {
                 TriggersPrefix = "trg_",
                 TriggersSuffix = "_trg"
@@ -122,7 +122,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var scopeName = "scope";
 
             var options = new SyncOptions();
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" })
+            var setup = new SyncSetup("SalesLT.Product")
             {
                 TriggersPrefix = "trg_",
                 TriggersSuffix = "_trg"
@@ -151,7 +151,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var scopeName = "scope";
 
             var options = new SyncOptions();
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" })
+            var setup = new SyncSetup("SalesLT.Product")
             {
                 TriggersPrefix = "trg_",
                 TriggersSuffix = "_trg"
@@ -182,7 +182,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var scopeName = "scope";
 
             var options = new SyncOptions();
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" })
+            var setup = new SyncSetup("SalesLT.Product")
             {
                 TriggersPrefix = "trg_",
                 TriggersSuffix = "_trg"
@@ -206,7 +206,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             var scopeName = "scope";
 
             var options = new SyncOptions();
-            var setup = new SyncSetup(new string[] { "SalesLT.Product" });
+            var setup = new SyncSetup("SalesLT.Product");
 
             setup.TriggersPrefix = "trg_";
             setup.TriggersSuffix = "_trg";

--- a/Tests/Dotmim.Sync.Tests/UnitTests/SyncSetup/SyncSetupTests.cs
+++ b/Tests/Dotmim.Sync.Tests/UnitTests/SyncSetup/SyncSetupTests.cs
@@ -11,14 +11,14 @@ namespace Dotmim.Sync.Tests.UnitTests
         [Fact]
         public void SyncSetup_Compare_TwoSetup_ShouldBe_Equals()
         {
-            SyncSetup setup1 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
-            SyncSetup setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            SyncSetup setup1 = new SyncSetup("Product", "ProductCategory", "Employee");
+            SyncSetup setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
 
             Assert.Equal(setup1, setup2);
             Assert.True(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
 
             Assert.Equal(setup1, setup2);
             Assert.True(setup1.Equals(setup2));
@@ -55,14 +55,14 @@ namespace Dotmim.Sync.Tests.UnitTests
         [Fact]
         public void SyncSetup_Compare_TwoSetup_ShouldBe_Different()
         {
-            SyncSetup setup1 = new SyncSetup(new string[] { "Product1", "ProductCategory", "Employee" });
-            SyncSetup setup2 = new SyncSetup(new string[] { "Product2", "ProductCategory", "Employee" });
+            SyncSetup setup1 = new SyncSetup("Product1", "ProductCategory", "Employee");
+            SyncSetup setup2 = new SyncSetup("Product2", "ProductCategory", "Employee");
 
             Assert.NotEqual(setup1, setup2);
             Assert.False(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory1", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory2", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory1", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory2", "Employee");
 
             Assert.NotEqual(setup1, setup2);
             Assert.False(setup1.Equals(setup2));
@@ -99,56 +99,56 @@ namespace Dotmim.Sync.Tests.UnitTests
         [Fact]
         public void SyncSetup_Compare_TwoSetup_Properties_ShouldBe_Equals()
         {
-            var setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            var setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            var setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            var setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.StoredProceduresPrefix = "sp";
             setup2.StoredProceduresPrefix = "sp";
 
             Assert.Equal(setup1, setup2);
             Assert.True(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.StoredProceduresSuffix = "sp";
             setup2.StoredProceduresSuffix = "sp";
 
             Assert.Equal(setup1, setup2);
             Assert.True(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.TriggersPrefix = "sp";
             setup2.TriggersPrefix = "sp";
 
             Assert.Equal(setup1, setup2);
             Assert.True(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.TriggersSuffix = "sp";
             setup2.TriggersSuffix = "sp";
 
             Assert.Equal(setup1, setup2);
             Assert.True(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.TrackingTablesPrefix = "sp";
             setup2.TrackingTablesPrefix = "sp";
 
             Assert.Equal(setup1, setup2);
             Assert.True(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.TrackingTablesSuffix = "sp";
             setup2.TrackingTablesSuffix = "sp";
 
             Assert.Equal(setup1, setup2);
             Assert.True(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
 
             Assert.Equal(setup1, setup2);
             Assert.True(setup1.Equals(setup2));
@@ -156,96 +156,96 @@ namespace Dotmim.Sync.Tests.UnitTests
         [Fact]
         public void SyncSetup_Compare_TwoSetup_Properties_ShouldBe_Different()
         {
-            var setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            var setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            var setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            var setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.StoredProceduresPrefix = "sp1";
             setup2.StoredProceduresPrefix = "sp";
 
             Assert.NotEqual(setup1, setup2);
             Assert.False(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.StoredProceduresPrefix = null;
             setup2.StoredProceduresPrefix = "sp";
 
             Assert.NotEqual(setup1, setup2);
             Assert.False(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.StoredProceduresSuffix = "sp1";
             setup2.StoredProceduresSuffix = "sp";
 
             Assert.NotEqual(setup1, setup2);
             Assert.False(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.StoredProceduresSuffix = null;
             setup2.StoredProceduresSuffix = "sp";
 
             Assert.NotEqual(setup1, setup2);
             Assert.False(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.TriggersPrefix = "sp1";
             setup2.TriggersPrefix = "sp";
 
             Assert.NotEqual(setup1, setup2);
             Assert.False(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.TriggersPrefix = "sp1";
             setup2.TriggersPrefix = null;
 
             Assert.NotEqual(setup1, setup2);
             Assert.False(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.TriggersSuffix = "sp1";
             setup2.TriggersSuffix = "sp";
 
             Assert.NotEqual(setup1, setup2);
             Assert.False(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.TriggersSuffix = "sp1";
             setup2.TriggersSuffix = null;
 
             Assert.NotEqual(setup1, setup2);
             Assert.False(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.TrackingTablesPrefix = "sp1";
             setup2.TrackingTablesPrefix = "sp";
 
             Assert.NotEqual(setup1, setup2);
             Assert.False(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.TrackingTablesPrefix = null;
             setup2.TrackingTablesPrefix = "sp";
 
             Assert.NotEqual(setup1, setup2);
             Assert.False(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.TrackingTablesSuffix = "sp1";
             setup2.TrackingTablesSuffix = "sp";
 
             Assert.NotEqual(setup1, setup2);
             Assert.False(setup1.Equals(setup2));
 
-            setup1 = new SyncSetup(new string[] { "Employee", "ProductCategory", "Product" });
-            setup2 = new SyncSetup(new string[] { "Product", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Employee", "ProductCategory", "Product");
+            setup2 = new SyncSetup("Product", "ProductCategory", "Employee");
             setup1.TrackingTablesSuffix = null;
             setup2.TrackingTablesSuffix = "sp";
 
@@ -257,8 +257,8 @@ namespace Dotmim.Sync.Tests.UnitTests
         [Fact]
         public void SyncSetup_Compare_TwoSetup_With_Filters_ShouldBe_Equals()
         {
-            SyncSetup setup1 = new SyncSetup(new string[] { "Customer", "Product", "ProductCategory", "Employee" });
-            SyncSetup setup2 = new SyncSetup(new string[] { "Customer", "Product", "ProductCategory", "Employee" });
+            SyncSetup setup1 = new SyncSetup("Customer", "Product", "ProductCategory", "Employee");
+            SyncSetup setup2 = new SyncSetup("Customer", "Product", "ProductCategory", "Employee");
 
             setup1.Filters.Add("Customer", "CompanyName");
 
@@ -328,19 +328,19 @@ namespace Dotmim.Sync.Tests.UnitTests
         public void SyncSetup_Compare_TwoSetup_With_Filters_ShouldBe_Different()
         {
             // Check Setup shoul be differents when tables names count is not same
-            SyncSetup setup1 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory" });
-            SyncSetup setup2 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee" });
+            SyncSetup setup1 = new SyncSetup("Customer", "Address", "ProductCategory");
+            SyncSetup setup2 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee");
             Assert.False(setup1.EqualsByProperties(setup2));
 
             // Check Setup should be differents when tables names are differents
-            setup1 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee1" });
-            setup2 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee2" });
+            setup1 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee1");
+            setup2 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee2");
             Assert.False(setup1.EqualsByProperties(setup2));
 
 
             // Check when Setup Filter names are differente (Customer1 and Customer2)
-            setup1 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee" });
-            setup2 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee");
+            setup2 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee");
 
             setup1.Filters.Add("Customer1", "CompanyName");
 
@@ -363,8 +363,8 @@ namespace Dotmim.Sync.Tests.UnitTests
             Assert.False(setup1.EqualsByProperties(setup2));
 
             // 2) Check when Setup Filter names are differente (Address1 and Address2)
-            setup1 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee" });
-            setup2 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee");
+            setup2 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee");
 
             setup1.Filters.Add("Customer", "CompanyName");
 
@@ -387,8 +387,8 @@ namespace Dotmim.Sync.Tests.UnitTests
             Assert.False(setup1.EqualsByProperties(setup2));
 
             // 3) Check when Setup Parameter names are differente (CompanyName1 and CompanyName2)
-            setup1 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee" });
-            setup2 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee");
+            setup2 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee");
 
             setup1.Filters.Add("Customer", "CompanyName");
 
@@ -411,8 +411,8 @@ namespace Dotmim.Sync.Tests.UnitTests
             Assert.False(setup1.EqualsByProperties(setup2));
 
             // 4) Check when Setup Joins names are differente (CustomerAddress1 and CustomerAddress2)
-            setup1 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee" });
-            setup2 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee");
+            setup2 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee");
 
             setup1.Filters.Add("Customer", "CompanyName");
 
@@ -435,8 +435,8 @@ namespace Dotmim.Sync.Tests.UnitTests
             Assert.False(setup1.EqualsByProperties(setup2));
 
             // 5) Check when Setup Where names are differente (CompanyName1 and CompanyName2)
-            setup1 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee" });
-            setup2 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee");
+            setup2 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee");
 
             setup1.Filters.Add("Customer", "CompanyName");
 
@@ -459,8 +459,8 @@ namespace Dotmim.Sync.Tests.UnitTests
             Assert.False(setup1.EqualsByProperties(setup2));
 
             // 6) Check CustomWhere differences
-            setup1 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee" });
-            setup2 = new SyncSetup(new string[] { "Customer", "Address", "ProductCategory", "Employee" });
+            setup1 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee");
+            setup2 = new SyncSetup("Customer", "Address", "ProductCategory", "Employee");
 
             setup1.Filters.Add("Customer", "CompanyName");
 


### PR DESCRIPTION
Avoids array creation by using the `params` syntax that was already existing. 