### PR TITLE
Add xUnit analyzer, and fix warnings

### DIFF
--- a/Tests/Dotmim.Sync.Tests/Dotmim.Sync.Tests.csproj
+++ b/Tests/Dotmim.Sync.Tests/Dotmim.Sync.Tests.csproj
@@ -37,6 +37,10 @@
 		<PackageReference Include="MessagePack" Version="2.5.168" />
 		<PackageReference Include="xunit" Version="2.8.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+		<PackageReference Include="xunit.analyzers" Version="1.14.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkNetCore)'">

--- a/Tests/Dotmim.Sync.Tests/UnitTests/Orchestrators/RemoteOrchestrator.Snapshots.Tests.cs
+++ b/Tests/Dotmim.Sync.Tests/UnitTests/Orchestrators/RemoteOrchestrator.Snapshots.Tests.cs
@@ -148,7 +148,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             await using var summaryStream = File.OpenRead(summaryFile);
             var summaryObject = JsonDocument.Parse(summaryStream).RootElement;
 
-            Assert.NotEqual(summaryObject.ValueKind, JsonValueKind.Null);
+            Assert.NotEqual(JsonValueKind.Null, summaryObject.ValueKind);
             string summaryDirname = summaryObject.GetProperty("dirname").GetString();
             Assert.NotNull(summaryDirname);
             Assert.Equal("ALL", summaryDirname);
@@ -237,7 +237,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             await using var summaryStream = File.OpenRead(summaryFile);
             var summaryObject = JsonDocument.Parse(summaryStream).RootElement;
 
-            Assert.NotEqual(summaryObject.ValueKind, JsonValueKind.Null);
+            Assert.NotEqual(JsonValueKind.Null, summaryObject.ValueKind);
             string summaryDirname = summaryObject.GetProperty("dirname").GetString();
             Assert.NotNull(summaryDirname);
             Assert.Equal("CompanyName_ABikeStore", summaryDirname);

--- a/Tests/Dotmim.Sync.Tests/UnitTests/Orchestrators/RemoteOrchestrator.Snapshots.Tests.cs
+++ b/Tests/Dotmim.Sync.Tests/UnitTests/Orchestrators/RemoteOrchestrator.Snapshots.Tests.cs
@@ -148,7 +148,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             await using var summaryStream = File.OpenRead(summaryFile);
             var summaryObject = JsonDocument.Parse(summaryStream).RootElement;
 
-            Assert.True(summaryObject.ValueKind != JsonValueKind.Null);
+            Assert.NotEqual(summaryObject.ValueKind, JsonValueKind.Null);
             string summaryDirname = summaryObject.GetProperty("dirname").GetString();
             Assert.NotNull(summaryDirname);
             Assert.Equal("ALL", summaryDirname);
@@ -164,7 +164,7 @@ namespace Dotmim.Sync.Tests.UnitTests
 
             var firstPart = parts[0];
             Assert.NotNull(firstPart.GetProperty("file").GetString());
-            Assert.True(firstPart.GetProperty("index").GetInt32() == 0);
+            Assert.Equal(0, firstPart.GetProperty("index").GetInt32());
             Assert.False(firstPart.GetProperty("last").GetBoolean());
         }
 
@@ -237,7 +237,7 @@ namespace Dotmim.Sync.Tests.UnitTests
             await using var summaryStream = File.OpenRead(summaryFile);
             var summaryObject = JsonDocument.Parse(summaryStream).RootElement;
 
-            Assert.True(summaryObject.ValueKind != JsonValueKind.Null);
+            Assert.NotEqual(summaryObject.ValueKind, JsonValueKind.Null);
             string summaryDirname = summaryObject.GetProperty("dirname").GetString();
             Assert.NotNull(summaryDirname);
             Assert.Equal("CompanyName_ABikeStore", summaryDirname);
@@ -253,7 +253,7 @@ namespace Dotmim.Sync.Tests.UnitTests
 
             var firstPart = parts[0];
             Assert.NotNull(firstPart.GetProperty("file").GetString());
-            Assert.True(firstPart.GetProperty("index").GetInt32() == 0);
+            Assert.Equal(0, firstPart.GetProperty("index").GetInt32());
             Assert.False(firstPart.GetProperty("last").GetBoolean());
         }
 

--- a/Tests/Dotmim.Sync.Tests/packages.lock.json
+++ b/Tests/Dotmim.Sync.Tests/packages.lock.json
@@ -113,6 +113,12 @@
           "xunit.core": "[2.8.1]"
         }
       },
+      "xunit.analyzers": {
+        "type": "Direct",
+        "requested": "[1.14.0, )",
+        "resolved": "1.14.0",
+        "contentHash": "KcFBmV2150xZHPUebV3YLR5gGl8R4wLuPOoxMiwCf1L4bL8ls0dcwtGFzr6NvQRgg6dWgSqbE52I6SYyeB0VnQ=="
+      },
       "xunit.runner.visualstudio": {
         "type": "Direct",
         "requested": "[2.4.5, )",
@@ -981,11 +987,6 @@
         "resolved": "2.0.3",
         "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
       },
-      "xunit.analyzers": {
-        "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "KcFBmV2150xZHPUebV3YLR5gGl8R4wLuPOoxMiwCf1L4bL8ls0dcwtGFzr6NvQRgg6dWgSqbE52I6SYyeB0VnQ=="
-      },
       "xunit.assert": {
         "type": "Transitive",
         "resolved": "2.8.1",
@@ -1175,6 +1176,12 @@
           "xunit.assert": "2.8.1",
           "xunit.core": "[2.8.1]"
         }
+      },
+      "xunit.analyzers": {
+        "type": "Direct",
+        "requested": "[1.14.0, )",
+        "resolved": "1.14.0",
+        "contentHash": "KcFBmV2150xZHPUebV3YLR5gGl8R4wLuPOoxMiwCf1L4bL8ls0dcwtGFzr6NvQRgg6dWgSqbE52I6SYyeB0VnQ=="
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
@@ -1768,11 +1775,6 @@
         "resolved": "2.0.3",
         "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
       },
-      "xunit.analyzers": {
-        "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "KcFBmV2150xZHPUebV3YLR5gGl8R4wLuPOoxMiwCf1L4bL8ls0dcwtGFzr6NvQRgg6dWgSqbE52I6SYyeB0VnQ=="
-      },
       "xunit.assert": {
         "type": "Transitive",
         "resolved": "2.8.1",
@@ -1949,6 +1951,12 @@
           "xunit.assert": "2.8.1",
           "xunit.core": "[2.8.1]"
         }
+      },
+      "xunit.analyzers": {
+        "type": "Direct",
+        "requested": "[1.14.0, )",
+        "resolved": "1.14.0",
+        "contentHash": "KcFBmV2150xZHPUebV3YLR5gGl8R4wLuPOoxMiwCf1L4bL8ls0dcwtGFzr6NvQRgg6dWgSqbE52I6SYyeB0VnQ=="
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
@@ -2419,11 +2427,6 @@
         "type": "Transitive",
         "resolved": "2.0.3",
         "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
-      },
-      "xunit.analyzers": {
-        "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "KcFBmV2150xZHPUebV3YLR5gGl8R4wLuPOoxMiwCf1L4bL8ls0dcwtGFzr6NvQRgg6dWgSqbE52I6SYyeB0VnQ=="
       },
       "xunit.assert": {
         "type": "Transitive",


### PR DESCRIPTION
The xUnit analyzers are useful, and having the development nuget package allows them to work in a more cross-platform and cross-IDE manner.

And with it, theoretically, the warnings could be converted into pipeline errors.