### PR TITLE
don't warn for CA2007 in sample console

### DIFF
--- a/Samples/Dotmim.Sync.SampleConsole/Dotmim.Sync.SampleConsole.csproj
+++ b/Samples/Dotmim.Sync.SampleConsole/Dotmim.Sync.SampleConsole.csproj
@@ -6,6 +6,7 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+		<NoWarn>$(NoWarn);CA2007</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Tests/Dotmim.Sync.Tests/Dotmim.Sync.Tests.csproj
+++ b/Tests/Dotmim.Sync.Tests/Dotmim.Sync.Tests.csproj
@@ -11,7 +11,7 @@
 		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
 	</PropertyGroup>
 	<PropertyGroup>
-		<NoWarn>CA2007</NoWarn>
+		<NoWarn>$(NoWarn);CA2007</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Remove="UnitTests\Mock\**" />


### PR DESCRIPTION
There is no synchronization context in a console app, by default

https://stackoverflow.com/questions/25817703/configureawaitfalse-not-needed-in-console-win-service-apps-right