### PR TITLE
don't warn about documentation in tests

### DIFF
--- a/Tests/Dotmim.Sync.Tests/Dotmim.Sync.Tests.csproj
+++ b/Tests/Dotmim.Sync.Tests/Dotmim.Sync.Tests.csproj
@@ -2,6 +2,8 @@
 	<PropertyGroup>
 		<TargetFrameworks>$(TargetFrameworkNet6);$(TargetFrameworkNet8);$(TargetFrameworkNetCore)</TargetFrameworks>
 
+		<NoWarn>$(NoWarn);CS1587;CS1591</NoWarn>
+
 		<IsPackable>false</IsPackable>
 		<!--<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>-->
 		<LangVersion>12.0</LangVersion>


### PR DESCRIPTION
when building via command line, these warnings clutter the logs