### PR TITLE
Only query table list once

### DIFF
--- a/Projects/Dotmim.Sync.Core/Orchestrators/ApplyChanges/BaseOrchestrator.ApplyChanges.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/ApplyChanges/BaseOrchestrator.ApplyChanges.cs
@@ -49,8 +49,8 @@ namespace Dotmim.Sync
                         $@"[InternalApplyChangesAsync]. directory {{DirectoryName}} BatchPartsInfo count: {{BatchPartsInfoCount}} RowsCount {{RowsCount}}",
                         message.Changes.DirectoryName, message.Changes.BatchPartsInfo.Count, message.Changes.RowsCount);
 
-                    var schemaTables = message.Schema.Tables.SortByDependencies(tab => tab.GetRelations().Select(r => r.GetParentTable())).ToList();
-                    var reverseSchemaTables = message.Schema.Tables.SortByDependencies(tab => tab.GetRelations().Select(r => r.GetParentTable())).Reverse().ToList();
+                    var schemaTables = message.Schema.Tables.SortByDependencies(tab => tab.GetRelations().Select(r => r.GetParentTable())).ToArray();
+                    var reverseSchemaTables = schemaTables.Reverse();
 
                     // create local directory
                     if (!string.IsNullOrEmpty(message.BatchDirectory) && !Directory.Exists(message.BatchDirectory))

--- a/Projects/Dotmim.Sync.Core/Orchestrators/Builders/BaseOrchestrator.Table.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/Builders/BaseOrchestrator.Table.cs
@@ -122,8 +122,8 @@ namespace Dotmim.Sync
                     var atLeastOneHasBeenCreated = false;
 
                     // Sorting tables based on dependencies between them
-                    var schemaTables = scopeInfo.Schema.Tables.SortByDependencies(tab => tab.GetRelations().Select(r => r.GetParentTable())).ToList();
-                    var reverseSchemaTables = scopeInfo.Schema.Tables.SortByDependencies(tab => tab.GetRelations().Select(r => r.GetParentTable())).Reverse().ToList();
+                    var schemaTables = scopeInfo.Schema.Tables.SortByDependencies(tab => tab.GetRelations().Select(r => r.GetParentTable())).ToArray();
+                    var reverseSchemaTables = schemaTables.Reverse();
 
                     // if we overwritten all tables, we need to delete all of them, before recreating them
                     if (overwrite)

--- a/Projects/Dotmim.Sync.Core/Orchestrators/Metadatas/BaseOrchestrator.Metadatas.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/Metadatas/BaseOrchestrator.Metadatas.cs
@@ -151,12 +151,14 @@ namespace Dotmim.Sync
 
                     if (syncRowCountParam != null && syncRowCountParam.Value != null && syncRowCountParam.Value != DBNull.Value)
                         metadataUpdatedRowsCount = (int)syncRowCountParam.Value;
-
-                    command.Dispose();
                 }
                 catch (Exception ex)
                 {
                     exception = ex;
+                }
+                finally
+                {
+                    command.Dispose();
                 }
 
                 return (context, metadataUpdatedRowsCount > 0, exception);


### PR DESCRIPTION
This is a redundant LINQ query and list creation operation that is happening all the time.

Threw in another fix for a possible memory leak