### PR TITLE
remove redundant CloseFile calls

### DIFF
--- a/Projects/Dotmim.Sync.Core/Orchestrators/ApplyChanges/BaseOrchestrator.ApplyChanges.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/ApplyChanges/BaseOrchestrator.ApplyChanges.cs
@@ -466,10 +466,6 @@ namespace Dotmim.Sync
                     }
                     finally
                     {
-                        // Close file
-                        if (localSerializer.IsOpen)
-                            await localSerializer.CloseFileAsync().ConfigureAwait(false);
-
                         if (runner != null)
                             await runner.DisposeAsync().ConfigureAwait(false);
                     }
@@ -883,13 +879,11 @@ namespace Dotmim.Sync
             {
                 if (localSerializerWriter != null)
                 {
-                    await localSerializerWriter.CloseFileAsync().ConfigureAwait(false);
                     await localSerializerWriter.DisposeAsync().ConfigureAwait(false);
                 }
 
                 if (localSerializerReader != null)
                 {
-                    await localSerializerReader.CloseFileAsync().ConfigureAwait(false);
                     await localSerializerReader.DisposeAsync().ConfigureAwait(false);
                 }
             }

--- a/Projects/Dotmim.Sync.Core/Orchestrators/ApplyChanges/LocalOrchestrator.ApplyChanges.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/ApplyChanges/LocalOrchestrator.ApplyChanges.cs
@@ -183,8 +183,6 @@ namespace Dotmim.Sync
                             foreach (var row in table.Rows)
                                 await localSerializer.WriteRowToFileAsync(row, table).ConfigureAwait(false);
 
-                            await localSerializer.CloseFileAsync().ConfigureAwait(false);
-
                             batchIndex++;
                         }
 

--- a/Projects/Dotmim.Sync.Core/Orchestrators/ApplyChanges/RemoteOrchestrator.ApplyChanges.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/ApplyChanges/RemoteOrchestrator.ApplyChanges.cs
@@ -173,8 +173,6 @@ namespace Dotmim.Sync
                                     foreach (var row in table.Rows)
                                         await localSerializer.WriteRowToFileAsync(row, table).ConfigureAwait(false);
 
-                                    await localSerializer.CloseFileAsync().ConfigureAwait(false);
-
                                     batchIndex++;
                                 }
                             }

--- a/Projects/Dotmim.Sync.Core/Orchestrators/BaseOrchestrator.BatchInfo.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/BaseOrchestrator.BatchInfo.cs
@@ -294,8 +294,6 @@ namespace Dotmim.Sync
 
             foreach (var row in syncTable.Rows)
                 await localSerializer.WriteRowToFileAsync(row, syncTable).ConfigureAwait(false);
-
-            await localSerializer.CloseFileAsync().ConfigureAwait(false);
         }
     }
 }

--- a/Projects/Dotmim.Sync.Web.Client/Orchestrators/WebRemoteOrchestrator.GetChanges.cs
+++ b/Projects/Dotmim.Sync.Web.Client/Orchestrators/WebRemoteOrchestrator.GetChanges.cs
@@ -235,8 +235,6 @@ namespace Dotmim.Sync.Web.Client
 
                         await localSerializer.WriteRowToFileAsync(syncRow, schemaTable).ConfigureAwait(false);
                     }
-
-                    await localSerializer.CloseFileAsync().ConfigureAwait(false);
                 }
             }
             else

--- a/Projects/Dotmim.Sync.Web.Server/WebServerAgent.cs
+++ b/Projects/Dotmim.Sync.Web.Server/WebServerAgent.cs
@@ -899,8 +899,6 @@ namespace Dotmim.Sync.Web.Server
                     await localSerializer.WriteRowToFileAsync(syncRow, schemaTable).ConfigureAwait(false);
                 }
 
-                await localSerializer.CloseFileAsync().ConfigureAwait(false);
-
                 var bpi = new BatchPartInfo
                 {
                     FileName = fileName,

--- a/Tests/Dotmim.Sync.Tests/UnitTests/BatchInfos/BatchInfosTests.cs
+++ b/Tests/Dotmim.Sync.Tests/UnitTests/BatchInfos/BatchInfosTests.cs
@@ -120,8 +120,6 @@ namespace Dotmim.Sync.Tests.UnitTests
             foreach (var row in tCustomer.Rows)
                 await localSerializer.WriteRowToFileAsync(row, tCustomer);
 
-            await localSerializer.CloseFileAsync();
-
             return (batchInfo, tCustomer);
         }
 


### PR DESCRIPTION
The `Dispose` and `DisposeAsync` methods already try to close the file because of the `using` statement.

Indeed, the `using` statement is superior, because it will close the file even in the event of an exception, and obviates the need for try-finally logic.