### PR TITLE
Remove redundant link in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,8 +4,6 @@
 [![Build Status](https://dev.azure.com/dotmim/Dotmim.Sync/_apis/build/status/Tests)](https://dev.azure.com/dotmim/Dotmim.Sync/_build/latest?definitionId=9)
 [![Documentation Status](https://readthedocs.org/projects/dotmimsync/badge/?version=master)](https://dotmimsync.readthedocs.io/?badge=master)
 
-See the Azure Devops CI : [https://dev.azure.com/dotmim/Dotmim.Sync](https://dev.azure.com/dotmim/Dotmim.Sync)
-
 ## Documentation
 
 Read the full documentation on [https://dotmimsync.readthedocs.io/](https://dotmimsync.readthedocs.io/)


### PR DESCRIPTION
This just clutters the Readme. The build status badge links to the same place.