### PR TITLE
Add Exclude columns feature

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
 		<!-- Restore the exact packages as listed in the lock file -->
 		<RestoreLockedMode Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</RestoreLockedMode>
 
-		<Version>1.3.0</Version>
+		<Version>1.3.1</Version>
 		<VersionSuffix>$(VersionSuffix)</VersionSuffix>
 		<Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
 

--- a/Projects/Dotmim.Sync.Core/Orchestrators/BaseOrchestrator.Schema.cs
+++ b/Projects/Dotmim.Sync.Core/Orchestrators/BaseOrchestrator.Schema.cs
@@ -247,13 +247,11 @@ namespace Dotmim.Sync
                 if (schemaTable.Columns.Count > 0)
                     schemaTable.Columns.Clear();
 
-                List<SyncColumn> lstColumns;
+                List<SyncColumn> lstColumns = new List<SyncColumn>();
 
                 // Validate columns list from setup table if any
                 if (setupTable.Columns != null && setupTable.Columns.Count > 1)
                 {
-                    lstColumns = new List<SyncColumn>();
-
                     foreach (var setupColumn in setupTable.Columns)
                     {
                         // Check if the columns list contains the column name we specified in the setup
@@ -267,7 +265,8 @@ namespace Dotmim.Sync
                 }
                 else
                 {
-                    lstColumns = columnsList;
+                    // Add all columns except the excluded ones
+                    lstColumns.AddRange(columnsList.Where(column => !setupTable.Columns.ExcludedCollection.Any(e => e.Equals(column.ColumnName, SyncGlobalization.DataSourceStringComparison))));
                 }
 
                 foreach (var column in lstColumns.OrderBy(c => c.Ordinal))

--- a/Projects/Dotmim.Sync.Core/Setup/SetupColumns.cs
+++ b/Projects/Dotmim.Sync.Core/Setup/SetupColumns.cs
@@ -21,6 +21,11 @@ namespace Dotmim.Sync
         [DataMember(Name = "c", IsRequired = true, Order = 1)]
         public Collection<string> InnerCollection { get; set; } = [];
 
+        /// <summary>
+        /// Gets or sets the columns that are to be excluded from the synchronization process.
+        /// </summary>
+        public Collection<string> ExcludedCollection { get; } = [];
+
         /// <inheritdoc cref="SetupColumns"/>
         public SetupColumns() { }
 
@@ -34,6 +39,9 @@ namespace Dotmim.Sync
 
             if (this.InnerCollection.Any(c => string.Equals(c, item, SyncGlobalization.DataSourceStringComparison)))
                 throw new Exception($"Column name {columnNameNormalized} already exists in the table");
+
+            if (this.ExcludedCollection.Any(c => string.Equals(c, item, SyncGlobalization.DataSourceStringComparison)))
+                throw new Exception($"Column name {columnNameNormalized} is in the exclusion collection");
 
             this.InnerCollection.Add(columnNameNormalized);
         }
@@ -54,6 +62,15 @@ namespace Dotmim.Sync
         {
             foreach (var columnName in columnsName)
                 this.Add(columnName);
+        }
+
+        /// <summary>
+        /// Exclude a range of columns from the sync process setup.
+        /// </summary>
+        public void ExcludeRange(params string[] columnsName)
+        {
+            foreach (var columnName in columnsName)
+                this.ExcludedCollection.Add(columnName);
         }
 
         /// <summary>

--- a/Projects/Dotmim.Sync.Core/Setup/SetupColumns.cs
+++ b/Projects/Dotmim.Sync.Core/Setup/SetupColumns.cs
@@ -34,19 +34,7 @@ namespace Dotmim.Sync
         /// </summary>
         public void Add(string item)
         {
-            var parserColumnName = new ObjectParser(item);
-            var columnNameNormalized = parserColumnName.ObjectName;
-
-            if (this.InnerCollection.Any(c => string.Equals(c, item, SyncGlobalization.DataSourceStringComparison)))
-                throw new Exception($"Column name {columnNameNormalized} already exists in the table");
-
-            // Column was in the excluded list, so we remove it as we are adding it later
-            if (this.ExcludedCollection.Any(c => string.Equals(c, item, SyncGlobalization.DataSourceStringComparison)))
-            {
-                this.ExcludedCollection.Remove(item);
-            }
-
-            this.InnerCollection.Add(columnNameNormalized);
+            MergeCollections(this.InnerCollection, this.ExcludedCollection, item, "already exists in the table");
         }
 
         /// <summary>
@@ -72,19 +60,7 @@ namespace Dotmim.Sync
         /// </summary>
         public void Exclude(string item)
         {
-            var parserColumnName = new ObjectParser(item);
-            var columnNameNormalized = parserColumnName.ObjectName;
-
-            if (this.ExcludedCollection.Any(c => string.Equals(c, item, SyncGlobalization.DataSourceStringComparison)))
-                throw new Exception($"Column name {columnNameNormalized} has already been excluded");
-
-            // Column was in the inner collection list, so we remove it as we are excluding it later
-            if (this.InnerCollection.Any(c => string.Equals(c, item, SyncGlobalization.DataSourceStringComparison)))
-            {
-                this.InnerCollection.Remove(item);
-            }
-
-            this.ExcludedCollection.Add(columnNameNormalized);
+            MergeCollections(this.ExcludedCollection, this.InnerCollection, item, "has already been excluded");
         }
 
         /// <summary>
@@ -185,5 +161,22 @@ namespace Dotmim.Sync
         /// Returns an enumerator that iterates through the list of columns to be added to the sync.
         /// </summary>
         IEnumerator IEnumerable.GetEnumerator() => this.InnerCollection.GetEnumerator();
+
+        private void MergeCollections(ICollection<string> collectionToAddTo, ICollection<string> collectionToDeleteFrom, string item, string errorMessage)
+        {
+            var parserColumnName = new ObjectParser(item);
+            var columnNameNormalized = parserColumnName.ObjectName;
+
+            if (collectionToAddTo.Any(c => string.Equals(c, item, SyncGlobalization.DataSourceStringComparison)))
+                throw new Exception($"Column name {columnNameNormalized} {errorMessage}");
+
+            // Column was in the excluded list, so we remove it as we are adding it later
+            if (collectionToDeleteFrom.Any(c => string.Equals(c, item, SyncGlobalization.DataSourceStringComparison)))
+            {
+                collectionToDeleteFrom.Remove(item);
+            }
+
+            collectionToAddTo.Add(columnNameNormalized);
+        }
     }
 }

--- a/Projects/Dotmim.Sync.Core/Setup/SetupColumns.cs
+++ b/Projects/Dotmim.Sync.Core/Setup/SetupColumns.cs
@@ -40,8 +40,11 @@ namespace Dotmim.Sync
             if (this.InnerCollection.Any(c => string.Equals(c, item, SyncGlobalization.DataSourceStringComparison)))
                 throw new Exception($"Column name {columnNameNormalized} already exists in the table");
 
+            // Column was in the excluded list, so we remove it as we are adding it later
             if (this.ExcludedCollection.Any(c => string.Equals(c, item, SyncGlobalization.DataSourceStringComparison)))
-                throw new Exception($"Column name {columnNameNormalized} is in the exclusion collection");
+            {
+                this.ExcludedCollection.Remove(item);
+            }
 
             this.InnerCollection.Add(columnNameNormalized);
         }
@@ -67,10 +70,39 @@ namespace Dotmim.Sync
         /// <summary>
         /// Exclude a range of columns from the sync process setup.
         /// </summary>
+        public void Exclude(string item)
+        {
+            var parserColumnName = new ObjectParser(item);
+            var columnNameNormalized = parserColumnName.ObjectName;
+
+            if (this.ExcludedCollection.Any(c => string.Equals(c, item, SyncGlobalization.DataSourceStringComparison)))
+                throw new Exception($"Column name {columnNameNormalized} has already been excluded");
+
+            // Column was in the inner collection list, so we remove it as we are excluding it later
+            if (this.InnerCollection.Any(c => string.Equals(c, item, SyncGlobalization.DataSourceStringComparison)))
+            {
+                this.InnerCollection.Remove(item);
+            }
+
+            this.ExcludedCollection.Add(columnNameNormalized);
+        }
+
+        /// <summary>
+        /// Exclude a range of columns from the sync process setup.
+        /// </summary>
         public void ExcludeRange(params string[] columnsName)
         {
             foreach (var columnName in columnsName)
-                this.ExcludedCollection.Add(columnName);
+                this.Exclude(columnName);
+        }
+
+        /// <summary>
+        /// Exclude a range of columns from the sync process setup.
+        /// </summary>
+        public void ExcludeRange(IEnumerable<string> columnsName)
+        {
+            foreach (var columnName in columnsName)
+                this.Exclude(columnName);
         }
 
         /// <summary>

--- a/Projects/Dotmim.Sync.Core/packages.lock.json
+++ b/Projects/Dotmim.Sync.Core/packages.lock.json
@@ -347,9 +347,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.Core/packages.lock.json
+++ b/Projects/Dotmim.Sync.Core/packages.lock.json
@@ -347,9 +347,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.MariaDB/packages.lock.json
+++ b/Projects/Dotmim.Sync.MariaDB/packages.lock.json
@@ -367,9 +367,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.MariaDB/packages.lock.json
+++ b/Projects/Dotmim.Sync.MariaDB/packages.lock.json
@@ -367,9 +367,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.MySql/packages.lock.json
+++ b/Projects/Dotmim.Sync.MySql/packages.lock.json
@@ -367,9 +367,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.MySql/packages.lock.json
+++ b/Projects/Dotmim.Sync.MySql/packages.lock.json
@@ -367,9 +367,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.PostgreSql/packages.lock.json
+++ b/Projects/Dotmim.Sync.PostgreSql/packages.lock.json
@@ -416,9 +416,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.PostgreSql/packages.lock.json
+++ b/Projects/Dotmim.Sync.PostgreSql/packages.lock.json
@@ -416,9 +416,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.SqlServer.ChangeTracking/packages.lock.json
+++ b/Projects/Dotmim.Sync.SqlServer.ChangeTracking/packages.lock.json
@@ -962,9 +962,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.SqlServer.ChangeTracking/packages.lock.json
+++ b/Projects/Dotmim.Sync.SqlServer.ChangeTracking/packages.lock.json
@@ -547,7 +547,7 @@
       "dotmim.sync.sqlserver": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Data.SqlClient": "[5.2.2, )"
         }
       }
@@ -948,7 +948,7 @@
       "dotmim.sync.sqlserver": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Data.SqlClient": "[5.2.2, )"
         }
       }
@@ -962,9 +962,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -1315,7 +1315,7 @@
       "dotmim.sync.sqlserver": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Data.SqlClient": "[5.2.2, )"
         }
       }

--- a/Projects/Dotmim.Sync.SqlServer/packages.lock.json
+++ b/Projects/Dotmim.Sync.SqlServer/packages.lock.json
@@ -966,9 +966,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.SqlServer/packages.lock.json
+++ b/Projects/Dotmim.Sync.SqlServer/packages.lock.json
@@ -966,9 +966,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.Sqlite/packages.lock.json
+++ b/Projects/Dotmim.Sync.Sqlite/packages.lock.json
@@ -457,9 +457,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.Sqlite/packages.lock.json
+++ b/Projects/Dotmim.Sync.Sqlite/packages.lock.json
@@ -457,9 +457,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.Web.Client/packages.lock.json
+++ b/Projects/Dotmim.Sync.Web.Client/packages.lock.json
@@ -443,9 +443,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.Web.Client/packages.lock.json
+++ b/Projects/Dotmim.Sync.Web.Client/packages.lock.json
@@ -443,9 +443,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.Web.Server/packages.lock.json
+++ b/Projects/Dotmim.Sync.Web.Server/packages.lock.json
@@ -501,9 +501,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Projects/Dotmim.Sync.Web.Server/packages.lock.json
+++ b/Projects/Dotmim.Sync.Web.Server/packages.lock.json
@@ -310,7 +310,7 @@
       "dotmim.sync.web.client": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.Extensions.Features": "[6.0.0, )",
           "Microsoft.Net.Http.Headers": "[2.2.8, )"
@@ -486,7 +486,7 @@
       "dotmim.sync.web.client": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.Extensions.Features": "[6.0.0, )"
         }
@@ -501,9 +501,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -613,7 +613,7 @@
       "dotmim.sync.web.client": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Extensions.Features": "[8.0.6, )",
           "Microsoft.Net.Http.Headers": "[8.0.6, )"
         }

--- a/Samples/Dotmim.Sync.SampleConsole/packages.lock.json
+++ b/Samples/Dotmim.Sync.SampleConsole/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "9SWRKJzFrE07m77G/9jSR1lqdlPmKCsQX1UflZEFBGYzmOZ53sjLEEcAiWtnWY0QJ750h2ahciOPO8oVjztQ0g=="
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "09sjUN6lE2os7s3qZDKsZQvng84wquilKCMY+cWD993evNSW9kII9Gm6j+xI0bT/x0CNDdhkHDyAbB47ObF8Bw=="
       },
       "Microsoft.EntityFrameworkCore.SqlServer": {
         "type": "Direct",
@@ -79,9 +79,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
       },
       "NLog.Web.AspNetCore": {
         "type": "Direct",

--- a/Samples/Dotmim.Sync.SampleConsole/packages.lock.json
+++ b/Samples/Dotmim.Sync.SampleConsole/packages.lock.json
@@ -79,9 +79,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "NLog.Web.AspNetCore": {
         "type": "Direct",
@@ -694,48 +694,48 @@
       "dotmim.sync.mariadb": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "MySqlConnector": "[2.3.7, )"
         }
       },
       "dotmim.sync.mysql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "MySqlConnector": "[2.3.7, )"
         }
       },
       "dotmim.sync.postgresql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Npgsql": "[8.0.3, )"
         }
       },
       "dotmim.sync.sqlite": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Data.Sqlite": "[8.0.6, )"
         }
       },
       "dotmim.sync.sqlserver": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Data.SqlClient": "[5.2.2, )"
         }
       },
       "dotmim.sync.sqlserver.changetracking": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.SqlServer": "[1.3.0, )"
+          "Dotmim.Sync.SqlServer": "[1.3.1, )"
         }
       },
       "dotmim.sync.web.client": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Extensions.Features": "[8.0.6, )",
           "Microsoft.Net.Http.Headers": "[8.0.6, )"
         }
@@ -743,7 +743,7 @@
       "dotmim.sync.web.server": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Web.Client": "[1.3.0, )",
+          "Dotmim.Sync.Web.Client": "[1.3.1, )",
           "System.Text.Json": "[8.0.5, )"
         }
       }

--- a/Tests/Dotmim.Sync.Tests/UnitTests/SyncSetup/SetupColumnsTests.cs
+++ b/Tests/Dotmim.Sync.Tests/UnitTests/SyncSetup/SetupColumnsTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Dotmim.Sync.Tests.UnitTests
+{
+    public class SetupColumnsTests
+    {
+        [Fact]
+        public void SetupColumns_Add_WithoutExcludedColumns_Should_AddAllColumns()
+        {
+            SetupColumns columns = new SetupColumns();
+            columns.AddRange("CustomerID", "CustomerName", "CustomerAddress");
+
+            Assert.Equal(3, columns.Count);
+            Assert.Equal(0, columns.ExcludedCollection.Count);
+            Assert.Contains("CustomerID", columns.InnerCollection);
+            Assert.Contains("CustomerName", columns.InnerCollection);
+            Assert.Contains("CustomerAddress", columns.InnerCollection);
+        }
+
+        [Fact]
+        public void SetupColumns_Exclude_WithoutAddedColumns_Should_ExcludeAllColumns()
+        {
+            SetupColumns columns = new SetupColumns();
+            columns.ExcludeRange("CustomerID", "CustomerName", "CustomerAddress");
+
+            Assert.Equal(0, columns.Count);
+            Assert.Equal(3, columns.ExcludedCollection.Count);
+            Assert.Contains("CustomerID", columns.ExcludedCollection);
+            Assert.Contains("CustomerName", columns.ExcludedCollection);
+            Assert.Contains("CustomerAddress", columns.ExcludedCollection);
+        }
+
+        [Fact]
+        public void SetupColumns_Exclude_AfterAddColumns_Should_NotContainExcludedColumns()
+        {
+            SetupColumns columns = new SetupColumns();
+            columns.AddRange("CustomerID", "CustomerName", "CustomerAddress");
+            columns.ExcludeRange("CustomerName", "CustomerAddress");
+
+            Assert.Equal(1, columns.Count);
+            Assert.Contains("CustomerID", columns.InnerCollection);
+            Assert.DoesNotContain("CustomerAddress", columns.InnerCollection);
+            Assert.DoesNotContain("CustomerName", columns.InnerCollection);
+            Assert.Equal(2, columns.ExcludedCollection.Count);
+            Assert.Contains("CustomerName", columns.ExcludedCollection);
+            Assert.Contains("CustomerAddress", columns.ExcludedCollection);
+        }
+
+        [Fact]
+        public void SetupColumns_Add_AfterExcludeColumns_Should_ContainAllAddedColumns()
+        {
+            SetupColumns columns = new SetupColumns();
+            columns.ExcludeRange("CustomerName", "CustomerAddress");
+            columns.AddRange("CustomerID", "CustomerName", "CustomerAddress");
+
+            Assert.Equal(3, columns.Count);
+            Assert.Equal(0, columns.ExcludedCollection.Count);
+            Assert.Contains("CustomerID", columns.InnerCollection);
+            Assert.Contains("CustomerName", columns.InnerCollection);
+            Assert.Contains("CustomerAddress", columns.InnerCollection);
+        }
+
+    }
+}

--- a/Tests/Dotmim.Sync.Tests/packages.lock.json
+++ b/Tests/Dotmim.Sync.Tests/packages.lock.json
@@ -1894,9 +1894,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",

--- a/Tests/Dotmim.Sync.Tests/packages.lock.json
+++ b/Tests/Dotmim.Sync.Tests/packages.lock.json
@@ -991,48 +991,48 @@
       "dotmim.sync.mariadb": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "MySqlConnector": "[0.69.10, )"
         }
       },
       "dotmim.sync.mysql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "MySqlConnector": "[0.69.10, )"
         }
       },
       "dotmim.sync.postgresql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Npgsql": "[8.0.3, )"
         }
       },
       "dotmim.sync.sqlite": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Data.Sqlite": "[8.0.6, )"
         }
       },
       "dotmim.sync.sqlserver": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Data.SqlClient": "[5.2.2, )"
         }
       },
       "dotmim.sync.sqlserver.changetracking": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.SqlServer": "[1.3.0, )"
+          "Dotmim.Sync.SqlServer": "[1.3.1, )"
         }
       },
       "dotmim.sync.web.client": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.Extensions.Features": "[6.0.0, )",
           "Microsoft.Net.Http.Headers": "[2.2.8, )"
@@ -1041,7 +1041,7 @@
       "dotmim.sync.web.server": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Web.Client": "[1.3.0, )",
+          "Dotmim.Sync.Web.Client": "[1.3.1, )",
           "Microsoft.AspNetCore.Http.Abstractions": "[2.1.1, )",
           "Microsoft.AspNetCore.Http.Extensions": "[2.1.21, )",
           "Microsoft.Extensions.DependencyInjection": "[3.1.32, )",
@@ -1792,48 +1792,48 @@
       "dotmim.sync.mariadb": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "MySqlConnector": "[2.3.7, )"
         }
       },
       "dotmim.sync.mysql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "MySqlConnector": "[2.3.7, )"
         }
       },
       "dotmim.sync.postgresql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Npgsql": "[8.0.3, )"
         }
       },
       "dotmim.sync.sqlite": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Data.Sqlite": "[8.0.6, )"
         }
       },
       "dotmim.sync.sqlserver": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Data.SqlClient": "[5.2.2, )"
         }
       },
       "dotmim.sync.sqlserver.changetracking": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.SqlServer": "[1.3.0, )"
+          "Dotmim.Sync.SqlServer": "[1.3.1, )"
         }
       },
       "dotmim.sync.web.client": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.Extensions.Features": "[6.0.0, )"
         }
@@ -1841,7 +1841,7 @@
       "dotmim.sync.web.server": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Web.Client": "[1.3.0, )",
+          "Dotmim.Sync.Web.Client": "[1.3.1, )",
           "System.Text.Json": "[8.0.5, )"
         }
       }
@@ -1894,9 +1894,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
@@ -2468,48 +2468,48 @@
       "dotmim.sync.mariadb": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "MySqlConnector": "[2.3.7, )"
         }
       },
       "dotmim.sync.mysql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "MySqlConnector": "[2.3.7, )"
         }
       },
       "dotmim.sync.postgresql": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Npgsql": "[8.0.3, )"
         }
       },
       "dotmim.sync.sqlite": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Data.Sqlite": "[8.0.6, )"
         }
       },
       "dotmim.sync.sqlserver": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Data.SqlClient": "[5.2.2, )"
         }
       },
       "dotmim.sync.sqlserver.changetracking": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.SqlServer": "[1.3.0, )"
+          "Dotmim.Sync.SqlServer": "[1.3.1, )"
         }
       },
       "dotmim.sync.web.client": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Core": "[1.3.0, )",
+          "Dotmim.Sync.Core": "[1.3.1, )",
           "Microsoft.Extensions.Features": "[8.0.6, )",
           "Microsoft.Net.Http.Headers": "[8.0.6, )"
         }
@@ -2517,7 +2517,7 @@
       "dotmim.sync.web.server": {
         "type": "Project",
         "dependencies": {
-          "Dotmim.Sync.Web.Client": "[1.3.0, )",
+          "Dotmim.Sync.Web.Client": "[1.3.1, )",
           "System.Text.Json": "[8.0.5, )"
         }
       }


### PR DESCRIPTION
Currently, when no columns are specified in the setup, it will sync all the table columns.

This adds an column exclusion feature, so that all columns except the excluded ones will be synchronized. It allows for simpler configuration when tables have many columns and we only want to exclude a few.
The excluded columns will not be taken into account at all if columns are specified in the setup.